### PR TITLE
Add support for push

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "firebase-admin": "^7 || ^8",
     "firebase-functions": "^2 || ^3",
     "lodash": "^4",
+    "nanoid": "^2.1.7",
     "object-path": "^0",
     "object.entries": "^1",
     "object.values": "^1"
@@ -30,6 +31,7 @@
   "devDependencies": {
     "@types/jest": "^24",
     "@types/lodash": "^4",
+    "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.7",
     "@types/object-path": "^0",
     "jest": "^24",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "firebase-admin": "^7 || ^8",
     "firebase-functions": "^2 || ^3",
     "lodash": "^4",
-    "nanoid": "^2.1.7",
     "object-path": "^0",
     "object.entries": "^1",
     "object.values": "^1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@types/jest": "^24",
     "@types/lodash": "^4",
-    "@types/nanoid": "^2.1.0",
     "@types/node": "^12.12.7",
     "@types/object-path": "^0",
     "jest": "^24",

--- a/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
@@ -47,6 +47,8 @@ export interface IFirebaseRealtimeDatabaseRef
     extends IFirebaseRealtimeDatabaseQuery {
     child(path: string): IFirebaseRealtimeDatabaseRef
 
+    push(path: string): IFirebaseRealtimeDatabaseRef
+
     set(value: any): Promise<void>
 
     update(value: object): Promise<void>

--- a/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
@@ -47,7 +47,7 @@ export interface IFirebaseRealtimeDatabaseRef
     extends IFirebaseRealtimeDatabaseQuery {
     child(path: string): IFirebaseRealtimeDatabaseRef
 
-    push(path: string): IFirebaseRealtimeDatabaseRef
+    push(path: string): Promise<IFirebaseRealtimeDatabaseRef>
 
     set(value: any): Promise<void>
 

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -208,8 +208,17 @@ class InProcessRealtimeDatabaseRef implements IFirebaseRealtimeDatabaseRef {
         return this.db.ref(`${this.path}/${path}`)
     }
 
-    push(): InProcessRealtimeDatabaseRef {
-        return this
+    async push(value: any): Promise<InProcessRealtimeDatabaseRef> {
+        if (value === undefined) {
+            throw new Error(
+                `Cannot push undefined onto Firebase Realtime Database path (${this.path})`,
+            )
+        }
+
+        const newPath = `${this.path}/${this.idGenerator()}`
+        await this.db._setPath(newPath, value)
+
+        return this.db.ref(newPath)
     }
 
     async set(value: any): Promise<void> {

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -1,5 +1,4 @@
 import _ from "lodash"
-import nanoid = require("nanoid")
 import objectPath = require("object-path")
 import { IAsyncJobs } from "../AsyncJobs"
 import {
@@ -7,6 +6,7 @@ import {
     IFirebaseBuilderDatabase,
     IFirebaseRefBuilder,
 } from "../FirebaseDriver"
+import { firebaseLikeId } from "../identifiers"
 import {
     IFirebaseChange,
     IFirebaseDataSnapshot,
@@ -92,7 +92,7 @@ class InProcessRealtimeDatabaseRef implements IFirebaseRealtimeDatabaseRef {
     constructor(
         private readonly db: InProcessRealtimeDatabase,
         private readonly path: string,
-        private readonly idGenerator: IdGenerator = nanoid,
+        private readonly idGenerator: IdGenerator = firebaseLikeId,
     ) {}
 
     orderByKey(): InProcessRealtimeDatabaseRef {
@@ -334,7 +334,7 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
 
     constructor(
         private readonly jobs?: IAsyncJobs,
-        private readonly idGenerator: IdGenerator = nanoid,
+        private readonly idGenerator: IdGenerator = firebaseLikeId,
     ) {}
 
     ref(path: string): InProcessRealtimeDatabaseRef {

--- a/src/driver/identifiers.ts
+++ b/src/driver/identifiers.ts
@@ -1,0 +1,1 @@
+export const firebaseLikeId = (time = Date.now()) => `-L${time.toString(16)}`

--- a/tests/driver/RealtimeDatabase/InProcessRealtimeDb.push.test.ts
+++ b/tests/driver/RealtimeDatabase/InProcessRealtimeDb.push.test.ts
@@ -1,0 +1,28 @@
+import { InProcessRealtimeDatabase } from "../../../src"
+
+describe("InProcessRealtimeDatabaseRef push", () => {
+    const newId = "new-id"
+
+    const database = new InProcessRealtimeDatabase(undefined, () => newId)
+
+    beforeEach(() => {
+        database.reset()
+    })
+
+    test("pushes new values inside", async () => {
+        // Given an in-process Firebase realtime database with a dataset;
+        database.reset({})
+
+        // When we push a new object;
+        await database.ref("").push({
+            key: "value",
+        })
+
+        // Then it should be added to the dataset
+        expect((await database.ref("").once("value")).val()).toEqual({
+            [newId]: {
+                key: "value",
+            },
+        })
+    })
+})


### PR DESCRIPTION
This adds support for `push` on the RealtimeDB references.

You can specify the ID you want it to generate when "pushing" a new value onto the object by passing an ID generator into the constructor, for example:

```js
const database = new InProcessRealtimeDatabase(undefined, () => newId)
```

If you don't specify one, it defaults to `nanoid`.

Personally, I'd prefer to make the constructor for `InProcessRealtimeDatabase` and InProcessRealtimeDatabaseRef` an object, so we can add keys as necessary. But this would be a breaking change to the public interface.