### PR TITLE
Allows tests to override the ID generation

### DIFF
--- a/src/driver/InProcessFirebaseDriver.ts
+++ b/src/driver/InProcessFirebaseDriver.ts
@@ -1,5 +1,6 @@
 import { IAsyncJobs } from "./AsyncJobs"
 import { IFirebaseDriver, IPubSub, MemoryOption } from "./FirebaseDriver"
+import { firebaseLikeId } from "./identifiers"
 import {
     InProcessFirebaseBuilderPubSub,
     InProcessFirebasePubSubCl,
@@ -9,8 +10,7 @@ import {
     IdGenerator,
     InProcessFirebaseBuilderDatabase,
     InProcessRealtimeDatabase,
-} from './RealtimeDatabase/InProcessRealtimeDatabase'
-import { firebaseLikeId } from './identifiers'
+} from "./RealtimeDatabase/InProcessRealtimeDatabase"
 
 class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
     constructor(

--- a/src/driver/InProcessFirebaseDriver.ts
+++ b/src/driver/InProcessFirebaseDriver.ts
@@ -6,9 +6,11 @@ import {
 } from "./PubSub/InProcessFirebasePubSub"
 import { IFirebaseFunctionBuilder } from "./RealtimeDatabase/IFirebaseRealtimeDatabase"
 import {
+    IdGenerator,
     InProcessFirebaseBuilderDatabase,
     InProcessRealtimeDatabase,
-} from "./RealtimeDatabase/InProcessRealtimeDatabase"
+} from './RealtimeDatabase/InProcessRealtimeDatabase'
+import { firebaseLikeId } from './identifiers'
 
 class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
     constructor(
@@ -25,9 +27,11 @@ export class InProcessFirebaseDriver implements IFirebaseDriver, IAsyncJobs {
     private builderPubSub: InProcessFirebaseBuilderPubSub | undefined
     private functionBuilder: InProcessFirebaseFunctionBuilder | undefined
 
-    realTimeDatabase(): InProcessRealtimeDatabase {
+    realTimeDatabase(
+        idGenerator: IdGenerator = firebaseLikeId,
+    ): InProcessRealtimeDatabase {
         if (!this.db) {
-            this.db = new InProcessRealtimeDatabase(this)
+            this.db = new InProcessRealtimeDatabase(this, idGenerator)
         }
         return this.db
     }


### PR DESCRIPTION
When testing uses of `push`, users need to be able to specify how the IDs are generated.

This is currently supported in the RealtimeDatabase, but the driver doesn't allow that to be passed through.

Before:

```js
    const firebase = inProcessFirebaseDriver()
    const database = firebase.realTimeDatabase()
```

After:

```js
    const firebase = inProcessFirebaseDriver()
    const database = firebase.realTimeDatabase(() => "constant-id")
```