### PR TITLE
Export InProcessFirebaseRefBuilder & InProcessRealtimeDatabaseRef

### DIFF
--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -535,7 +535,7 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
     }
 }
 
-class InProcessFirebaseRefBuilder implements IFirebaseRefBuilder {
+export class InProcessFirebaseRefBuilder implements IFirebaseRefBuilder {
     constructor(
         readonly path: string,
         private readonly database: InProcessRealtimeDatabase,

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -109,7 +109,8 @@ interface IInProcessRealtimeDatabaseRefQuery {
     readonly childOrderingPath?: string[]
 }
 
-class InProcessRealtimeDatabaseRef implements IFirebaseRealtimeDatabaseRef {
+export class InProcessRealtimeDatabaseRef
+    implements IFirebaseRealtimeDatabaseRef {
     constructor(
         readonly path: string,
         private readonly db: InProcessRealtimeDatabase,


### PR DESCRIPTION
Exports `InProcessRealtimeDatabaseRef` and `InProcessFirebaseRefBuilder` so that consumers can override the classes if needed. 