### PR TITLE
Re-throw caught errors for transactions

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -75,6 +75,7 @@ export class InProcessFirestore implements IFirestore {
             await transaction.commit()
         } catch (err) {
             this.storage = initialState
+            throw err
         }
 
         return result as T

--- a/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
@@ -50,4 +50,52 @@ describe("In-process Firestore transactions", () => {
             population: 860001,
         })
     })
+
+    test("throws errors from the inner transaction", async () => {
+        // Given we have a in-process Firestore DB;
+        const firestore = new InProcessFirestore()
+
+        // And there is some initial data;
+        const cityRef = firestore.collection("cities").doc("SF")
+        await cityRef.set({
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
+            capital: false,
+            population: 860000,
+        })
+
+        const error = new Error("SomeError")
+
+        // When we run a Firestore transaction on the data;
+        let transactionError
+        await firestore
+            .runTransaction<boolean>((t) => {
+                return t.get(cityRef).then((doc) => {
+                    const data = doc.data() as { population: number }
+                    const newPopulation = data.population + 1
+                    t.update(cityRef, { population: newPopulation })
+                    throw error
+                })
+            })
+            .then((result) => {
+                expect(result).toBeUndefined()
+            })
+            .catch((err: Error) => {
+                transactionError = err
+            })
+
+        // We get returned the error
+        expect(transactionError).toEqual(error)
+
+        // And the data should equal the initial state
+        const updatedDoc = await cityRef.get()
+        expect(updatedDoc.data()).toEqual({
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
+            capital: false,
+            population: 860000,
+        })
+    })
 })

--- a/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
@@ -70,7 +70,7 @@ describe("In-process Firestore transactions", () => {
         // When we run a Firestore transaction on the data;
         let transactionError
         await firestore
-            .runTransaction<boolean>((t) => {
+            .runTransaction((t) => {
                 return t.get(cityRef).then((doc) => {
                     const data = doc.data() as { population: number }
                     const newPopulation = data.population + 1


### PR DESCRIPTION
Re-throw caught errors after resetting the state for Inprocess Firestore