### PR TITLE
fix: null value and update error

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -753,6 +753,14 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         const data = dataOrField as IFirestoreDocumentData
         const precondition = valueOrPrecondition as IPrecondition
         const current = this.firestore._getPath(this._dotPath())
+
+        if (!current) {
+            throw new FirestoreError(
+                GRPCStatusCode.NOT_FOUND,
+                `No document to update: ${this.path}`,
+            )
+        }
+
         const newUpdateTime = makeTimestamp()
         const type = ChildType.DOC
         if (precondition && precondition.lastUpdateTime) {

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -706,7 +706,11 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         data: IFirestoreDocumentData,
         options: { merge: boolean } = { merge: false },
     ): Promise<IFirestoreWriteResult> {
-        if (options && options.merge) {
+        // We only need to do a merge if something exists at the path
+        // Due to how update is implemented, this will throw if it does
+        // not already exist
+        const current = this.firestore._getPath(this._dotPath())
+        if (options && options.merge && current) {
             return this.update(data)
         }
         const createTime = makeTimestamp()

--- a/src/util/stripMeta.ts
+++ b/src/util/stripMeta.ts
@@ -7,7 +7,8 @@ const isNotMeta = (input: any, key: string) => {
     return !(isMeta || hasMeta)
 }
 
-const isSubMeta = (input: any, key: string) => Boolean(input._meta)
+export const hasSubMeta = (input: any, key: string) =>
+    _.isObject(input) && Boolean((input as any)._meta)
 
 export function stripMeta<T extends { [key: string]: any }>(
     obj: T,
@@ -33,5 +34,5 @@ export function pickSubMeta<T extends { [key: string]: any }>(
     if (!_.isObject(obj)) {
         return obj
     }
-    return _.pickBy(obj, isSubMeta) as Omit<any, "_meta">
+    return _.pickBy(obj, hasSubMeta) as Omit<any, "_meta">
 }

--- a/tests/driver/Firestore/InProcessFirestore.batch.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.batch.test.ts
@@ -105,6 +105,26 @@ describe("In-process Firestore batched writes", () => {
         expect(losAngeles.data()).toEqual({})
     })
 
+    test.each([true, false])(
+        "can set in batch on a document that doesn't exist, with merge %s",
+        async (merge) => {
+            // Given we have a in-process Firestore DB;
+            const db = new InProcessFirestore()
+
+            // When we get a new write batch;
+            const batch = db.batch()
+
+            batch.set(db.doc("test/1"), { something: 1 }, { merge })
+
+            await batch.commit()
+
+            const result = await db.doc("test/1").get()
+
+            expect(result.exists).toBeTruthy()
+            expect(result.data()).toEqual({ something: 1 })
+        },
+    )
+
     test("cannot create existing document in a batch write", async () => {
         const db = new InProcessFirestore()
         // Given there is an existing document;

--- a/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.transaction.test.ts
@@ -5,7 +5,7 @@ describe("In-process Firestore transactions", () => {
      * https://firebase.google.com/docs/firestore/manage-data/transactions
      */
 
-    test("documentation example transaction", async () => {
+    test("documentation example transaction, update", async () => {
         // Given we have a in-process Firestore DB;
         const firestore = new InProcessFirestore()
 
@@ -17,6 +17,7 @@ describe("In-process Firestore transactions", () => {
             country: "USA",
             capital: false,
             population: 860000,
+            test: null,
         })
 
         // When we run a Firestore transaction on the data;
@@ -26,7 +27,10 @@ describe("In-process Firestore transactions", () => {
                 return t.get(cityRef).then((doc) => {
                     const data = doc.data() as { population: number }
                     const newPopulation = data.population + 1
-                    t.update(cityRef, { population: newPopulation })
+                    t.update(cityRef, {
+                        population: newPopulation,
+                        test: "123",
+                    })
                     return true
                 })
             })
@@ -47,6 +51,54 @@ describe("In-process Firestore transactions", () => {
             state: "CA",
             country: "USA",
             capital: false,
+            test: "123",
+            population: 860001,
+        })
+    })
+
+    test("documentation example transaction, set", async () => {
+        // Given we have a in-process Firestore DB;
+        const firestore = new InProcessFirestore()
+
+        // And there is some initial data;
+        const cityRef = firestore.collection("cities").doc("SF")
+        await cityRef.set({
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
+            capital: false,
+            test: null,
+            population: 860000,
+        })
+
+        // When we run a Firestore transaction on the data;
+        let transactionSuccessful
+        await firestore
+            .runTransaction<boolean>((t) => {
+                return t.get(cityRef).then((doc) => {
+                    const data = doc.data() as { population: number }
+                    const newPopulation = data.population + 1
+                    t.set(cityRef, {
+                        population: newPopulation,
+                        test: null,
+                    })
+                    return true
+                })
+            })
+            .then((result) => {
+                transactionSuccessful = result
+            })
+            .catch((err: Error) => {
+                expect(err).toBeUndefined()
+            })
+
+        // Then we should get the result;
+        expect(transactionSuccessful).toBe(true)
+
+        // And the data should be set correctly.
+        const updatedDoc = await cityRef.get()
+        expect(updatedDoc.data()).toEqual({
+            test: null,
             population: 860001,
         })
     })

--- a/tests/driver/Firestore/InProcessFirestore.update.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.update.test.ts
@@ -1,0 +1,54 @@
+import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
+import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
+
+describe("InProcessFirestore update", () => {
+    const firestore = new InProcessFirestore()
+
+    beforeEach(() => {
+        firestore.resetStorage()
+    })
+
+    test(".doc().update() new", async () => {
+        // When we update a new document in a collection;
+        await expect(
+            firestore
+                .collection("myCollection")
+                .doc("thing")
+                .update({
+                    name: "thing",
+                    good: true,
+                }),
+        ).rejects.isFirestoreErrorWithCode(GRPCStatusCode.NOT_FOUND)
+    })
+
+    test(".doc().update() existing", async () => {
+        // Given there is a doc;
+        await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .create({
+                name: "thing",
+                good: true,
+                nop: null,
+            })
+
+        // When we set the doc with a different value;
+        await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .update({ name: null })
+
+        // Then the data should be stored correctly;
+        const stored = await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .get()
+
+        expect(stored.exists).toBe(true)
+        expect(stored.data()).toEqual({
+            nop: null,
+            name: null,
+            good: true,
+        })
+    })
+})

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onCreate.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onCreate.test.ts
@@ -166,45 +166,6 @@ describe("onCreate trigger of in-process Firestore", () => {
         expect(receivedContexts).toHaveLength(0)
     })
 
-    test("onCreate handler triggered on creation via update method", async () => {
-        // Given we set up an onCreate handler on a doc;
-        const receivedSnapshots: IFirestoreChangeSnapshot[] = []
-        const receivedContexts: IChangeContext[] = []
-        driver
-            .runWith()
-            .region("europe-west1")
-            .firestore.document("/animals/{animalName}")
-            .onCreate(async (snapshot, context) => {
-                receivedSnapshots.push(snapshot)
-                receivedContexts.push(context)
-            })
-
-        // When that path is created via an update call;
-        await driver
-            .firestore()
-            .collection("animals")
-            .doc("tiger")
-            .update({ colour: "orange", size: "large" })
-
-        // And Firebase finishes its jobs;
-        await driver.jobsComplete()
-
-        // Then the handler should be triggered with the change and context.
-        expect(receivedSnapshots).toHaveLength(1)
-        expect(receivedSnapshots[0]).toBeTruthy()
-        expect(receivedSnapshots[0].exists).toBeTruthy()
-        expect(receivedSnapshots[0].data()).toEqual({
-            colour: "orange",
-            size: "large",
-        })
-
-        expect(receivedContexts).toHaveLength(1)
-        expect(receivedContexts[0]).toBeTruthy()
-        expect(receivedContexts[0]).toEqual({
-            params: { animalName: "tiger" },
-        })
-    })
-
     test("onCreate trigger with multiple path parameters", async () => {
         // Given we set up an onCreate handler with multiple path parameters;
         const receivedSnapshots: IFirestoreChangeSnapshot[] = []

--- a/tests/util/stripMeta.test.ts
+++ b/tests/util/stripMeta.test.ts
@@ -1,0 +1,10 @@
+import { hasSubMeta } from "../../src/util/stripMeta"
+
+describe("isSubMeta", () => {
+    test.each([true, false, null, "string", 1000])(
+        "handles $s type",
+        (input) => {
+            expect(hasSubMeta(input, "someKey")).toEqual(false)
+        },
+    )
+})


### PR DESCRIPTION
Fixes:
1. an issue where a null field causes an exception when attempting to strip meta
1. where update was allowed, but in the real firestore it throws 
1. fixes an issue with set and merge enabled