### PR TITLE
feat/Mimic Firestore by throwing when saving undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -707,7 +707,9 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
             updateDelta,
         )
         if (undefinedFields.length > 0) {
-            throw new Error(`Undefined fields cannot be stored in firestore`)
+            throw new Error(
+                `Undefined fields cannot be stored in firestore - Undefined fields: ${undefinedFields}`,
+            )
         }
     }
 

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -707,8 +707,9 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
             updateDelta,
         )
         if (undefinedFields.length > 0) {
-            throw new Error(
-                `Undefined fields cannot be stored in firestore - Undefined fields: ${undefinedFields}`,
+            throw new FirestoreError(
+                GRPCStatusCode.INVALID_ARGUMENT,
+                `Value for argument "data" is not a valid Firestore document. Cannot use "undefined" as a Firestore value (found in fields ${undefinedFields})`,
             )
         }
     }

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -700,6 +700,25 @@ interface IChildMeta {
 }
 
 export class InProcessFirestoreDocRef implements IFirestoreDocRef {
+    static validateNoUndefinedFields(
+        updateDelta: IFirestoreDocumentData,
+    ): void {
+        const undefinedFields = InProcessFirestoreDocRef.extractUndefinedFields(
+            updateDelta,
+        )
+        if (undefinedFields.length > 0) {
+            throw new Error(`Undefined fields cannot be stored in firestore`)
+        }
+    }
+
+    private static extractUndefinedFields(
+        updateDelta: IFirestoreDocumentData,
+    ): string[] {
+        return Object.keys(updateDelta).filter(
+            (path) => updateDelta[path] === undefined,
+        )
+    }
+
     readonly id: string
     readonly parent: IFirestoreCollectionRef
 
@@ -741,6 +760,7 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
                 `Document already exists: ${this.path}`,
             )
         }
+        InProcessFirestoreDocRef.validateNoUndefinedFields(data)
         return this.set(data)
     }
 
@@ -751,6 +771,7 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         // We only need to do a merge if something exists at the path
         // Due to how update is implemented, this will throw if it does
         // not already exist
+        InProcessFirestoreDocRef.validateNoUndefinedFields(data)
         const current = this.firestore._getPath(this._dotPath())
         if (options && options.merge && current) {
             return this.update(data)
@@ -797,6 +818,8 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         }
 
         const updateDelta = dataOrField as IFirestoreDocumentData
+        InProcessFirestoreDocRef.validateNoUndefinedFields(updateDelta)
+
         const precondition = valueOrPrecondition as IPrecondition
         const current = this.firestore._getPath(this._dotPath())
 

--- a/tests/driver/Firestore/InProcessFirestore.batch.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.batch.test.ts
@@ -1,5 +1,6 @@
 import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
 import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
+import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
 
 /**
  * https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes
@@ -186,5 +187,21 @@ describe("In-process Firestore batched writes", () => {
         expect(error).not.toBeUndefined()
         // @ts-ignore
         expect(error).toBeInstanceOf(Error)
+    })
+
+    test("throws if an undefined field is written in a batch", async () => {
+        // Given we have a write batch;
+        const db = new InProcessFirestore()
+        const batch = db.batch()
+
+        // And we make a change in the batch;
+        const docRef = db.collection("things").doc("thingA")
+        batch.create(docRef, { foo: "bar", bar: undefined })
+
+        // The commit should throw
+        await expect(batch.commit()).rejects.toThrowError(FirestoreError)
+
+        // And the db should be empty
+        expect(db.storage).toEqual({})
     })
 })

--- a/tests/driver/Firestore/InProcessFirestore.batch.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.batch.test.ts
@@ -1,6 +1,6 @@
 import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
-import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
 import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
+import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
 
 /**
  * https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes

--- a/tests/driver/Firestore/InProcessFirestore.set.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.set.test.ts
@@ -1,3 +1,4 @@
+import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
 import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
 
 describe("InProcessFirestore set", () => {
@@ -94,7 +95,7 @@ describe("InProcessFirestore set", () => {
                         name: "thing",
                         good: undefined,
                     }),
-            ).rejects.toThrow()
+            ).rejects.toThrowError(FirestoreError)
 
             // Then the data should not be stored;
             const stored = await firestore
@@ -153,7 +154,7 @@ describe("InProcessFirestore set", () => {
                         foo: undefined,
                         amount: 123,
                     }),
-            ).rejects.toThrow()
+            ).rejects.toThrowError(FirestoreError)
 
             // And the data should be not be updated;
             const stored = await firestore
@@ -203,7 +204,7 @@ describe("InProcessFirestore set", () => {
             firestore
                 .collection("myCollection")
                 .add({ foo: "bar", amount: undefined }),
-        ).rejects.toThrow()
+        ).rejects.toThrowError(FirestoreError)
 
         // And the data should be not be stores.
         const storedDoc = await firestore

--- a/tests/driver/Firestore/InProcessFirestore.set.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.set.test.ts
@@ -194,6 +194,27 @@ describe("InProcessFirestore set", () => {
         expect(storedDoc.data()).toEqual({ foo: "bar", amount: 123 })
     })
 
+    test(".collection().add() throws with an undefined field", async () => {
+        // Given Firestore can auto-generate ids;
+        firestore.makeId = () => "foobar-id-123"
+
+        // When we add a new doc to a collection, it should throw;
+        await expect(
+            firestore
+                .collection("myCollection")
+                .add({ foo: "bar", amount: undefined }),
+        ).rejects.toThrow()
+
+        // And the data should be not be stores.
+        const storedDoc = await firestore
+            .collection("myCollection")
+            .doc("foobar-id-123")
+            .get()
+
+        expect(storedDoc.exists).toBe(false)
+        expect(storedDoc.data()).toEqual({})
+    })
+
     test(".collection().doc().set() auto-id", async () => {
         // Given Firestore can auto-generate ids;
         firestore.makeId = () => "foobar-id-123"

--- a/tests/driver/Firestore/InProcessFirestore.set.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.set.test.ts
@@ -7,107 +7,164 @@ describe("InProcessFirestore set", () => {
         firestore.resetStorage()
     })
 
-    test(".doc().set() new", async () => {
-        // When we set a new document in a collection;
-        await firestore
-            .collection("myCollection")
-            .doc("thing")
-            .set({
+    describe(".doc().set()", () => {
+        test("new", async () => {
+            // When we set a new document in a collection;
+            await firestore
+                .collection("myCollection")
+                .doc("thing")
+                .set({
+                    name: "thing",
+                    good: true,
+                })
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("thing")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
                 name: "thing",
                 good: true,
             })
+        })
 
-        // Then the data should be stored correctly;
-        const stored = await firestore
-            .collection("myCollection")
-            .doc("thing")
-            .get()
-        expect(stored.exists).toBe(true)
-        expect(stored.data()).toEqual({
-            name: "thing",
-            good: true,
+        test("existing", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: { field: "value 1" },
+                },
+            })
+
+            // When we set the doc with a different value;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .set({ foo: "bar", amount: 123 })
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({ foo: "bar", amount: 123 })
+        })
+
+        test("merge", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: { field1: "value 1", field2: "value 2" },
+                },
+            })
+
+            // When we set the doc with a different value, using merge;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .set(
+                    { field2: "new value 2", foo: "bar", amount: 123 },
+                    { merge: true },
+                )
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
+                field1: "value 1",
+                field2: "new value 2",
+                foo: "bar",
+                amount: 123,
+            })
+        })
+
+        test("throws with an undefined field", async () => {
+            // When we set a new document in a collection, it throws;
+            await expect(
+                firestore
+                    .collection("myCollection")
+                    .doc("thing")
+                    .set({
+                        name: "thing",
+                        good: undefined,
+                    }),
+            ).rejects.toThrow()
+
+            // Then the data should not be stored;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("thing")
+                .get()
+            expect(stored.exists).toBe(false)
+            expect(stored.data()).toEqual({})
         })
     })
 
-    test(".doc().set() existing", async () => {
-        // Given there is a doc;
-        firestore.resetStorage({
-            myCollection: {
-                id1: { field: "value 1" },
-            },
+    describe(".doc().update()", () => {
+        test("update", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: { field1: "value 1", field2: "value 2" },
+                },
+            })
+
+            // When we update the doc with a different value;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .update({ field2: "new value 2", foo: "bar", amount: 123 })
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
+                field1: "value 1",
+                field2: "new value 2",
+                foo: "bar",
+                amount: 123,
+            })
         })
 
-        // When we set the doc with a different value;
-        await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .set({ foo: "bar", amount: 123 })
+        test("throws with an undefined field", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: { field1: "value 1", field2: "value 2" },
+                },
+            })
 
-        // Then the data should be stored correctly;
-        const stored = await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .get()
-        expect(stored.exists).toBe(true)
-        expect(stored.data()).toEqual({ foo: "bar", amount: 123 })
-    })
+            // When we update the doc with a different value, it throws;
+            await expect(
+                firestore
+                    .collection("myCollection")
+                    .doc("id1")
+                    .update({
+                        field2: "new value 2",
+                        foo: undefined,
+                        amount: 123,
+                    }),
+            ).rejects.toThrow()
 
-    test(".doc().set() merge", async () => {
-        // Given there is a doc;
-        firestore.resetStorage({
-            myCollection: {
-                id1: { field1: "value 1", field2: "value 2" },
-            },
-        })
-
-        // When we set the doc with a different value, using merge;
-        await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .set(
-                { field2: "new value 2", foo: "bar", amount: 123 },
-                { merge: true },
-            )
-
-        // Then the data should be stored correctly;
-        const stored = await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .get()
-        expect(stored.exists).toBe(true)
-        expect(stored.data()).toEqual({
-            field1: "value 1",
-            field2: "new value 2",
-            foo: "bar",
-            amount: 123,
-        })
-    })
-
-    test(".doc().update()", async () => {
-        // Given there is a doc;
-        firestore.resetStorage({
-            myCollection: {
-                id1: { field1: "value 1", field2: "value 2" },
-            },
-        })
-
-        // When we update the doc with a different value;
-        await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .update({ field2: "new value 2", foo: "bar", amount: 123 })
-
-        // Then the data should be stored correctly;
-        const stored = await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .get()
-        expect(stored.exists).toBe(true)
-        expect(stored.data()).toEqual({
-            field1: "value 1",
-            field2: "new value 2",
-            foo: "bar",
-            amount: 123,
+            // And the data should be not be updated;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
+                field1: "value 1",
+                field2: "value 2",
+            })
         })
     })
 


### PR DESCRIPTION
Mimics the behaviour of Firestore by throwing when an undefined value is saved to the database. This will assist in uncovering when a test saves a value incorrectly.

The error message will be near identical to the genuine Firestore implementation, but will display all fields that are undefined not just a single one.