### PR TITLE
Update verifyIdToken to take in checkRevoked argument

### DIFF
--- a/src/driver/Auth/FirebaseAuth.ts
+++ b/src/driver/Auth/FirebaseAuth.ts
@@ -1,6 +1,6 @@
 export interface IFirebaseAuth {
     createUser(properties: ICreateUserRequest): Promise<IUserRecord>
-    verifyIdToken(idToken: string): Promise<IDecodedIdToken>
+    verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<IDecodedIdToken>
 }
 
 interface ICreateUserRequest {
@@ -44,7 +44,7 @@ export class InProcessFirebaseAuth implements IFirebaseAuth {
      * No verification is done.
      * Simulates https://firebase.google.com/docs/auth/admin/verify-id-tokens
      */
-    async verifyIdToken(idToken: string): Promise<IDecodedIdToken> {
+    async verifyIdToken(idToken: string, checkRevoked: boolean = false): Promise<IDecodedIdToken> {
         const tokenParts = String(idToken).split(".")
         if (tokenParts.length !== 3) {
             throw new Error("Invalid JWT token structure")

--- a/src/driver/Auth/FirebaseAuth.ts
+++ b/src/driver/Auth/FirebaseAuth.ts
@@ -1,6 +1,9 @@
 export interface IFirebaseAuth {
     createUser(properties: ICreateUserRequest): Promise<IUserRecord>
-    verifyIdToken(idToken: string, checkRevoked?: boolean): Promise<IDecodedIdToken>
+    verifyIdToken(
+        idToken: string,
+        checkRevoked?: boolean,
+    ): Promise<IDecodedIdToken>
 }
 
 interface ICreateUserRequest {
@@ -44,7 +47,10 @@ export class InProcessFirebaseAuth implements IFirebaseAuth {
      * No verification is done.
      * Simulates https://firebase.google.com/docs/auth/admin/verify-id-tokens
      */
-    async verifyIdToken(idToken: string, checkRevoked: boolean = false): Promise<IDecodedIdToken> {
+    async verifyIdToken(
+        idToken: string,
+        checkRevoked: boolean = false,
+    ): Promise<IDecodedIdToken> {
         const tokenParts = String(idToken).split(".")
         if (tokenParts.length !== 3) {
             throw new Error("Invalid JWT token structure")


### PR DESCRIPTION
## Overview
The firebase-admin library auth method 'verifyIdToken' takes in a second argument:
![image](https://user-images.githubusercontent.com/4043189/88296472-a5913700-ccf6-11ea-8283-a8174035dcd2.png)

https://github.com/firebase/firebase-admin-node/blob/master/src/auth/auth.ts#L176
This PR updates the driver verifyIdToken implementation to also support that argument.