### PR TITLE
Serialize runTransaction executions

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -9,6 +9,7 @@ import {
 import { expandDotPaths } from "../../util/expandDotPaths"
 import { makeDelta } from "../../util/makeDelta"
 import { objDel, objGet, objHas, objSet } from "../../util/objPath"
+import { sleep } from "../../util/sleep"
 import { pickSubMeta, stripMeta } from "../../util/stripMeta"
 import { IAsyncJobs } from "../AsyncJobs"
 import {
@@ -46,6 +47,8 @@ import { makeTimestamp } from "./makeTimestamp"
 export class InProcessFirestore implements IFirestore {
     private changeObservers: IDatabaseChangeObserver[] = []
 
+    private mutex = false
+
     constructor(
         private readonly jobs?: IAsyncJobs,
         public makeId: () => string = fireStoreLikeId,
@@ -67,16 +70,26 @@ export class InProcessFirestore implements IFirestore {
         updateFunction: (transaction: IFirestoreTransaction) => Promise<T>,
         transactionOptions?: { maxAttempts?: number },
     ): Promise<T> {
-        const initialState = _.cloneDeep(this.storage)
-        const transaction = new InProcessFirestoreTransaction()
+        while (this.mutex) {
+            await sleep(1)
+        }
 
         let result
         try {
-            result = await updateFunction(transaction)
-            await transaction.commit()
-        } catch (err) {
-            this.storage = initialState
-            throw err
+            this.mutex = true
+
+            const initialState = _.cloneDeep(this.storage)
+            const transaction = new InProcessFirestoreTransaction()
+
+            try {
+                result = await updateFunction(transaction)
+                await transaction.commit()
+            } catch (err) {
+                this.storage = initialState
+                throw err
+            }
+        } finally {
+            this.mutex = false
         }
 
         return result as T

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -71,7 +71,7 @@ export class InProcessFirestore implements IFirestore {
         transactionOptions?: { maxAttempts?: number },
     ): Promise<T> {
         while (this.mutex) {
-            await sleep(1)
+            await sleep(0)
         }
 
         let result


### PR DESCRIPTION
Add a mutex variable to guarantee serial execution of runTransaction's
updateFunction.

The mutex variable is a simple boolean. Reading and updating mutex is
guaranteed to be executed atomically by the runtime: node is
single-threaded and only one 'process' at the time wakes up from `sleep(1)`.

Unfortunately this change breaks Firestore's transaction semantics, but
at least guarantees correctness.

This change fixes the following issue:
```
1.  two runTransaction run concurrently: A and B
2.1 transaction A starts before B and makes a copy of storage (initialState)
2.2 transaction B starts
3.1 transaction B completes successfully
3.2 transaction A fails
4.  transaction A resets storage to its initialState: transaction B work
    is undone.
```