### PR TITLE
feat/Adds 4GB memory option

### DIFF
--- a/src/driver/FirebaseDriver.ts
+++ b/src/driver/FirebaseDriver.ts
@@ -31,7 +31,7 @@ export interface IFirebaseDriver {
     auth(): IFirebaseAuth
 }
 
-export type MemoryOption = "128MB" | "256MB" | "512MB" | "1GB" | "2GB"
+export type MemoryOption = "128MB" | "256MB" | "512MB" | "1GB" | "2GB" | "4GB"
 
 export interface IPubSub {
     topic(name: string): IPubSubTopic


### PR DESCRIPTION
Adds the 4GB memory option, added to the `firebase-functions` library in [3.12.0](https://github.com/firebase/firebase-functions/releases/tag/v3.12.0.)