### PR TITLE
Feat/add startafter doc id

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,4 @@ accurate representation of the Firebase API than _ts-firebase-driver-testing_.
 The _Firebase Test SDK_ requires carefully stubbing out the correct parts of the Firebase
 application under test, whereas _ts-firebase-driver-testing_ allows swapping it all out and once and
 then checking that the application interacted with Firebase correctly.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "0.28.2",
+  "version": "0.28.3",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/driver/Firestore/InProcessFirestore.startAfter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.startAfter.test.ts
@@ -103,7 +103,7 @@ describe("In-process Firestore start after query", () => {
         ])
     })
 
-    test.only("startAfter document id", async () => {
+    test("startAfter document id", async () => {
         // Given there is a collection of documents with ids;
         await db.doc("animals/22da618d").set({ name: "aardvark" })
         await db.doc("animals/00a3382").set({ name: "badger" })

--- a/tests/driver/Firestore/InProcessFirestore.startAfter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.startAfter.test.ts
@@ -117,17 +117,9 @@ describe("In-process Firestore start after query", () => {
             .get()
 
         // Then we should get the collection ordered by that field.
-        const docs: Array<{
-            id: number
-            name: string
-        }> = result.docs.map((doc) => doc.data() as any)
-
-        expect(docs.map((doc) => doc.name)).not.toStrictEqual([
-            "aardvark",
-            "badger",
-            "camel",
-        ])
-        expect(docs.map((doc) => doc.name)).toStrictEqual(["aardvark"])
-        expect(docs).toStrictEqual([{ name: "aardvark" }])
+        expect(result.size).toEqual(1)
+        expect(
+            result.docs.map((doc) => ({ id: doc.id, data: doc.data() })),
+        ).toStrictEqual([{ id: "22da618d", data: { name: "aardvark" } }])
     })
 })


### PR DESCRIPTION
Adds the ability to call `query.orderBy(FieldPath.documentId()).startAfter('some-doc-id')`, so you can page using the doc's id akin to firestore.