### PR TITLE
Add Firestore Set w/ Merge - Deep Merge Functionality

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -849,6 +849,54 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         )
     }
 
+    async delete(): Promise<IFirestoreWriteResult> {
+        this.firestore._deletePath(this._dotPath())
+        return makeWriteResult()
+    }
+
+    async listCollections(): Promise<InProcessFirestoreCollectionRef[]> {
+        const collection = this.firestore._getPath(this._dotPath()) || {}
+        return Object.keys(collection)
+            .map((key: string): string[] => `${this.path}/${key}`.split("/"))
+            .filter((path: string[]): boolean => {
+                const valueAt = this.firestore._getPath(path)
+                return (
+                    typeof valueAt === "object" &&
+                    valueAt._meta &&
+                    valueAt._meta.type !== ChildType.DOC
+                )
+            })
+            .map(
+                (path: string[]): InProcessFirestoreCollectionRef => {
+                    return new InProcessFirestoreCollectionRef(
+                        this.firestore,
+                        path.join("/"),
+                    )
+                },
+            ) as InProcessFirestoreCollectionRef[]
+    }
+
+    onSnapshot(
+        onNext: (snapshot: IFirestoreDocumentSnapshot) => void,
+        onError?: (error: Error) => void,
+    ): () => void {
+        throw new Error("InProcessFirestoreDocRef.onSnapshot not implemented")
+    }
+
+    isEqual(other: IFirestoreDocRef): boolean {
+        throw new Error("InProcessFirestoreDocRef.onSnapshot not implemented")
+    }
+
+    withConverter<U>(converter: any): IFirestoreDocRef<U> {
+        throw new Error(
+            "InProcessFirestoreDocRef.withConverter not implemented",
+        )
+    }
+
+    _dotPath(): string[] {
+        return _.trim(this.path.replace(/[\/.]+/g, "."), ".").split(".")
+    }
+
     private async performUpdate(
         dataOrField: IFirestoreDocumentData | string | IFieldPath,
         { mergeWithExisting }: { mergeWithExisting: boolean },
@@ -902,54 +950,6 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
             ChildType.COLLECTION,
         )
         return makeWriteResult()
-    }
-
-    async delete(): Promise<IFirestoreWriteResult> {
-        this.firestore._deletePath(this._dotPath())
-        return makeWriteResult()
-    }
-
-    async listCollections(): Promise<InProcessFirestoreCollectionRef[]> {
-        const collection = this.firestore._getPath(this._dotPath()) || {}
-        return Object.keys(collection)
-            .map((key: string): string[] => `${this.path}/${key}`.split("/"))
-            .filter((path: string[]): boolean => {
-                const valueAt = this.firestore._getPath(path)
-                return (
-                    typeof valueAt === "object" &&
-                    valueAt._meta &&
-                    valueAt._meta.type !== ChildType.DOC
-                )
-            })
-            .map(
-                (path: string[]): InProcessFirestoreCollectionRef => {
-                    return new InProcessFirestoreCollectionRef(
-                        this.firestore,
-                        path.join("/"),
-                    )
-                },
-            ) as InProcessFirestoreCollectionRef[]
-    }
-
-    onSnapshot(
-        onNext: (snapshot: IFirestoreDocumentSnapshot) => void,
-        onError?: (error: Error) => void,
-    ): () => void {
-        throw new Error("InProcessFirestoreDocRef.onSnapshot not implemented")
-    }
-
-    isEqual(other: IFirestoreDocRef): boolean {
-        throw new Error("InProcessFirestoreDocRef.onSnapshot not implemented")
-    }
-
-    withConverter<U>(converter: any): IFirestoreDocRef<U> {
-        throw new Error(
-            "InProcessFirestoreDocRef.withConverter not implemented",
-        )
-    }
-
-    _dotPath(): string[] {
-        return _.trim(this.path.replace(/[\/.]+/g, "."), ".").split(".")
     }
 }
 

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -872,11 +872,16 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
                 _meta: { updateTime: newUpdateTime },
             }),
         )
-        for (const path of Object.keys(updateDelta)) {
-            if (path.includes(".")) {
-                objSet(newValue, path.split("."), updateDelta[path])
+        for (const [path, value] of Object.entries(updateDelta)) {
+            const pathComponents = path.includes(".") ? path.split(".") : [path]
+            const existingValue = objGet(newValue, pathComponents)
+            const isValueAnObject =
+                typeof value === "object" && !Array.isArray(value)
+
+            if (isValueAnObject) {
+                objSet(newValue, pathComponents, _.merge(existingValue, value))
             } else {
-                objSet(newValue, [path], updateDelta[path])
+                objSet(newValue, pathComponents, value)
             }
         }
         this.firestore._setPath(this._dotPath(), newValue)

--- a/tests/driver/Firestore/InProcessFirestore.set.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.set.test.ts
@@ -85,6 +85,45 @@ describe("InProcessFirestore set", () => {
             })
         })
 
+        test("merge deep", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: {
+                        container: {
+                            field2: 2,
+                        },
+                    },
+                },
+            })
+
+            // When we set the doc with a different value, using merge;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .set(
+                    {
+                        container: {
+                            field3: 3,
+                        },
+                    },
+                    { merge: true },
+                )
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
+                container: {
+                    field2: 2,
+                    field3: 3,
+                },
+            })
+        })
+
         test("throws with an undefined field", async () => {
             // When we set a new document in a collection, it throws;
             await expect(

--- a/tests/driver/Firestore/InProcessFirestore.update.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.update.test.ts
@@ -21,34 +21,37 @@ describe("InProcessFirestore update", () => {
         ).rejects.isFirestoreErrorWithCode(GRPCStatusCode.NOT_FOUND)
     })
 
-    test(".doc().update() existing", async () => {
-        // Given there is a doc;
-        await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .create({
-                name: "thing",
-                good: true,
+    test.each([null, "newValue", { someProperty: "value" }])(
+        ".doc().update() existing to %s",
+        async (update) => {
+            // Given there is a doc;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .create({
+                    name: "thing",
+                    good: true,
+                    nop: null,
+                })
+
+            // When we set the doc with a different value;
+            await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .update({ name: update })
+
+            // Then the data should be stored correctly;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
                 nop: null,
+                name: update,
+                good: true,
             })
-
-        // When we set the doc with a different value;
-        await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .update({ name: null })
-
-        // Then the data should be stored correctly;
-        const stored = await firestore
-            .collection("myCollection")
-            .doc("id1")
-            .get()
-
-        expect(stored.exists).toBe(true)
-        expect(stored.data()).toEqual({
-            nop: null,
-            name: null,
-            good: true,
-        })
-    })
+        },
+    )
 })


### PR DESCRIPTION
The real Firestore implementation supports merging deep objects when using `set(blah: { merge: true })` - it [does not support this](https://firebase.google.com/docs/firestore/manage-data/add-data#update_fields_in_nested_objects) for `update({ someProperty: { someNestedThing: 3 } })`. This can be demonstrated with the following sample code (I ran locally as a script against my personal environment)

```
    const docs = await db.collection('myCollection').listDocuments()
    for (const doc of docs) {
        await doc.delete()
    }

    await db
        .collection('myCollection')
        .doc('id1')
        .set({
            container: {
                field2: 2
            }
        })

    const beforeMerge = await db
        .collection('myCollection')
        .doc('id1')
        .get()

    // When we set the doc with a different value, using merge;
    await db
        .collection('myCollection')
        .doc('id1')
        .set(
            {
                container: {
                    field3: 3
                }
            },
            { merge: true }
        )

    // Then the data should be stored correctly;
    const afterMerge = await db
        .collection('myCollection')
        .doc('id1')
        .get()

    console.log('Before merge:', JSON.stringify(beforeMerge.data(), null, 4)) 
    console.log('After merge:', JSON.stringify(afterMerge.data(), null, 4))
```

Which prints out the following:
```
Before merge: {
    "container": {
        "field2": 2
    }
}
After merge: {
    "container": {
        "field3": 3,
        "field2": 2
    }
}
```

This updates the driver to work like the above firebase sample, by using a lodash merge when the property being set is an object.