### PR TITLE
Throw on nested object undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "0.28.4",
+  "version": "0.28.5",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -333,11 +333,12 @@ export class InProcessRealtimeDatabaseRef
     }
 
     async set(value: any): Promise<void> {
-        if (value === undefined) {
+        if (containsUndefinedDeep(value)) {
             throw new Error(
                 `Cannot set Firebase Realtime Database path to undefined (${this.path})`,
             )
         }
+
         this.db._setPath(this.path, value)
     }
 
@@ -617,4 +618,23 @@ function dotPathFromSlashed(path: string): string[] {
         .trim()
         .replace(/\/+/g, ".")
         .split(".")
+}
+
+function containsUndefinedDeep(value: any): boolean {
+    if (_.isObject(value)) {
+        return Object.keys(value).reduce(
+            (areAnyUndefined: boolean, currentKey: string) =>
+                containsUndefinedDeep((value as any)[currentKey]) ||
+                areAnyUndefined,
+            false,
+        )
+    }
+    if (Array.isArray(value)) {
+        return value.reduce(
+            (anyAreUndefined, current) =>
+                containsUndefinedDeep(current) || anyAreUndefined,
+            false,
+        )
+    }
+    return value === undefined
 }

--- a/tests/driver/RealtimeDatabase/InProcessRealtimeDb.get_set_update.test.ts
+++ b/tests/driver/RealtimeDatabase/InProcessRealtimeDb.get_set_update.test.ts
@@ -86,6 +86,37 @@ describe("InProcessRealtimeDatabaseRef get set", () => {
         },
     )
 
+    test("cannot set undefined", async () => {
+        // Given an in-process Firebase realtime database with a dataset;
+        database.reset({})
+
+        // When we set the value to undefined;
+        // Then the function should throw.
+        await expect(database.ref("animals").set(undefined)).rejects.toThrow()
+    })
+
+    test("cannot set an object with undefined", async () => {
+        // Given an in-process Firebase realtime database with a dataset;
+        database.reset({})
+
+        // When we set the value to an object with undefined;
+        // Then the function should throw.
+        await expect(
+            database.ref("animals").set({ name: "Bertie", age: undefined }),
+        ).rejects.toThrow()
+    })
+
+    test("cannot set an array with undefined", async () => {
+        // Given an in-process Firebase realtime database with a dataset;
+        database.reset({})
+
+        // When we set the value to undefined;
+        // Then the function should throw.
+        await expect(
+            database.ref("animals").set({ name: [undefined] }),
+        ).rejects.toThrow()
+    })
+
     test.each([
         [{}, "foobar", "hello", { foobar: "hello" }],
         [{ foobar: "hello" }, "foobar", "goodbye", { foobar: "goodbye" }],


### PR DESCRIPTION
Actual realtime database throws errors when it receives `set()` with an object containing undefined. This adds that same functionality.

Verified with actual RTDB script:
```
await db.ref('rorytest/thing').set({ a: undefined })
```

Threw this error:
```
(node:93472) UnhandledPromiseRejectionWarning: Error: Reference.set failed: First argument contains undefined in property 'rorytest.thing.a'
    at validateFirebaseData (/Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/core/util/validation.ts:145:11)
    at /Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/core/util/validation.ts:204:7
    at each (/Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/core/util/util.ts:417:7)
    at validateFirebaseData (/Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/core/util/validation.ts:185:5)
    at validateFirebaseDataArg (/Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/core/util/validation.ts:122:3)
    at Reference.set (/Users/rorybain/projects/freetrade-firebase-functions/functions/node_modules/firebase-admin/node_modules/@firebase/database/src/api/Reference.ts:137:5)
    at /Users/rorybain/projects/freetrade-firebase-functions/functions/admin/prod/test-rtdb.ts:32:36
    at Generator.next (<anonymous>)
    at /Users/rorybain/projects/freetrade-firebase-functions/functions/admin/prod/test-rtdb.ts:14:71
    at new Promise (<anonymous>)
(node:93472) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
```