### PR TITLE
Ensure that change observers use DocumentSnapshot for written changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,4 @@ The _Firebase Test SDK_ requires carefully stubbing out the correct parts of the
 application under test, whereas _ts-firebase-driver-testing_ allows swapping it all out and once and
 then checking that the application interacted with Firebase correctly.
 
+

--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -4,6 +4,7 @@ import objectPath = require("object-path")
 import { enumeratePaths } from "../../util/enumeratePaths"
 import { JsonValue } from "../../util/json"
 import { makeDelta } from "../../util/makeDelta"
+import { IFirestoreQueryDocumentSnapshot } from "../.."
 
 /**
  * Firebase triggers get before/after, GCP cloud function triggers get
@@ -11,8 +12,8 @@ import { makeDelta } from "../../util/makeDelta"
  * two setups.
  */
 export interface IChange {
-    before?: JsonValue | undefined
-    after?: JsonValue | undefined
+    before?: JsonValue | IFirestoreQueryDocumentSnapshot | undefined
+    after?: JsonValue | IFirestoreQueryDocumentSnapshot | undefined
     data?: JsonValue | undefined
     delta?: JsonValue | undefined
 }

--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -4,7 +4,6 @@ import objectPath = require("object-path")
 import { enumeratePaths } from "../../util/enumeratePaths"
 import { JsonValue } from "../../util/json"
 import { makeDelta } from "../../util/makeDelta"
-import { IFirestoreQueryDocumentSnapshot } from "../.."
 
 /**
  * Firebase triggers get before/after, GCP cloud function triggers get
@@ -12,8 +11,8 @@ import { IFirestoreQueryDocumentSnapshot } from "../.."
  * two setups.
  */
 export interface IChange {
-    before?: JsonValue | IFirestoreQueryDocumentSnapshot | undefined
-    after?: JsonValue | IFirestoreQueryDocumentSnapshot | undefined
+    before?: JsonValue | undefined
+    after?: JsonValue | undefined
     data?: JsonValue | undefined
     delta?: JsonValue | undefined
 }

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -1,4 +1,5 @@
 import _ from "lodash"
+import { InProcessFirestore, InProcessFirestoreDocRef } from "../.."
 import { JsonValue } from "../../util/json"
 import { stripMeta } from "../../util/stripMeta"
 import {
@@ -17,12 +18,11 @@ import {
 } from "../ChangeObserver/DatabaseChangeObserver"
 import {
     IFirestore,
+    IFirestoreDocRef,
     IFirestoreDocumentData,
     IFirestoreDocumentSnapshot,
-    IFirestoreDocRef,
 } from "./IFirestore"
 import { InProcessFirestoreDocumentSnapshot } from "./InProcessFirestoreDocumentSnapshot"
-import { InProcessFirestoreDocRef, InProcessFirestore } from "../.."
 
 export function makeFirestoreChangeObserver(
     changeType: ChangeType,

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -46,7 +46,11 @@ export function makeFirestoreChangeObserver(
                 firestore,
             )
         case "written":
-            return new FirestoreWrittenObserver(observedPath, handler, firestore)
+            return new FirestoreWrittenObserver(
+                observedPath,
+                handler,
+                firestore,
+            )
     }
 }
 

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -177,29 +177,12 @@ export class InProcessFirestore implements IFirestore {
             return
         }
 
-        const id = dotPath[dotPath.length - 1]
-        const path = dotPath.join("/")
-        const ref = new InProcessFirestoreDocRef(path, this) as IFirestoreDocRef
-
-        const beforeData = this._getPath(dotPath)
-        const before = new InProcessFirestoreDocumentSnapshot(
-            id,
-            !!beforeData,
-            ref,
-            beforeData,
-        )
-
+        const before = this._getPath(dotPath)
         makeChange()
-        const afterData = this._getPath(dotPath)
-        const after = new InProcessFirestoreDocumentSnapshot(
-            id,
-            !!afterData,
-            ref,
-            afterData,
-        )
+        const after = this._getPath(dotPath)
 
-        const data = beforeData
-        const delta = makeDelta(beforeData, afterData)
+        const data = before
+        const delta = makeDelta(before, after)
 
         const jobs = this.changeObservers.map(
             async (observer) =>

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -177,11 +177,29 @@ export class InProcessFirestore implements IFirestore {
             return
         }
 
-        const before = this._getPath(dotPath)
+        const id = dotPath[dotPath.length - 1]
+        const path = dotPath.join("/")
+        const ref = new InProcessFirestoreDocRef(path, this) as IFirestoreDocRef
+
+        const beforeData = this._getPath(dotPath)
+        const before = new InProcessFirestoreDocumentSnapshot(
+            id,
+            !!beforeData,
+            ref,
+            beforeData,
+        )
+
         makeChange()
-        const after = this._getPath(dotPath)
-        const data = before
-        const delta = makeDelta(before, after)
+        const afterData = this._getPath(dotPath)
+        const after = new InProcessFirestoreDocumentSnapshot(
+            id,
+            !!afterData,
+            ref,
+            afterData,
+        )
+
+        const data = beforeData
+        const delta = makeDelta(beforeData, afterData)
 
         const jobs = this.changeObservers.map(
             async (observer) =>

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
@@ -43,7 +43,7 @@ describe("onWrite trigger of in-process Firestore", () => {
         expect(receivedSnapshots).toHaveLength(1)
         expect(receivedSnapshots[0]).toBeTruthy()
         expect(receivedSnapshots[0].after?.exists).toBeTruthy()
-        expect(receivedSnapshots[0].after?.ref.path).toEqual("/animals/tiger")
+        expect(receivedSnapshots[0].after?.ref.path).toEqual("animals/tiger")
         expect(receivedSnapshots[0].after?.data()).toEqual({
             colour: "orange",
             size: "large",

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
@@ -1,9 +1,9 @@
 import {
-    IFirebaseDriver,
-    InProcessFirebaseDriver,
     IFirebaseChange,
-    IFirestoreDocumentSnapshot,
+    IFirebaseDriver,
     IFirestoreDocumentData,
+    IFirestoreDocumentSnapshot,
+    InProcessFirebaseDriver,
 } from "../../../../src"
 import { IChangeContext } from "../../../../src/driver/ChangeObserver/DatabaseChangeObserver"
 
@@ -16,9 +16,9 @@ describe("onWrite trigger of in-process Firestore", () => {
 
     test("onWrite handler is triggered on doc create", async () => {
         // Given we set up an onCreate handler on a collection;
-        const receivedSnapshots: IFirebaseChange<
+        const receivedSnapshots: Array<IFirebaseChange<
             IFirestoreDocumentSnapshot<IFirestoreDocumentData>
-        >[] = []
+        >> = []
         const receivedContexts: IChangeContext[] = []
         driver
             .runWith()

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onWrite.test.ts
@@ -1,0 +1,59 @@
+import {
+    IFirebaseDriver,
+    InProcessFirebaseDriver,
+    IFirebaseChange,
+    IFirestoreDocumentSnapshot,
+    IFirestoreDocumentData,
+} from "../../../../src"
+import { IChangeContext } from "../../../../src/driver/ChangeObserver/DatabaseChangeObserver"
+
+describe("onWrite trigger of in-process Firestore", () => {
+    let driver: InProcessFirebaseDriver & IFirebaseDriver
+
+    beforeEach(() => {
+        driver = new InProcessFirebaseDriver()
+    })
+
+    test("onWrite handler is triggered on doc create", async () => {
+        // Given we set up an onCreate handler on a collection;
+        const receivedSnapshots: IFirebaseChange<
+            IFirestoreDocumentSnapshot<IFirestoreDocumentData>
+        >[] = []
+        const receivedContexts: IChangeContext[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onWrite(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+                receivedContexts.push(context)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should be triggered with the change and context.
+        expect(receivedSnapshots).toHaveLength(1)
+        expect(receivedSnapshots[0]).toBeTruthy()
+        expect(receivedSnapshots[0].after?.exists).toBeTruthy()
+        expect(receivedSnapshots[0].after?.ref.path).toEqual("/animals/tiger")
+        expect(receivedSnapshots[0].after?.data()).toEqual({
+            colour: "orange",
+            size: "large",
+        })
+
+        expect(receivedContexts).toHaveLength(1)
+        expect(receivedContexts[0]).toBeTruthy()
+        expect(receivedContexts[0]).toEqual({
+            params: { animalName: "tiger" },
+            timestamp: expect.any(String),
+        })
+    })
+})


### PR DESCRIPTION
Actual Firestore passes through Snapshot objects for before and after which has `before.ref` and `after.ref`:

![image](https://user-images.githubusercontent.com/4043189/113855389-e0a99c80-9797-11eb-8394-3d742352e282.png)


This updates the Change observer for written events accordingly.