### PR TITLE
Fix cases where paths can contain special regex characters

### DIFF
--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -152,12 +152,14 @@ export class CreatedChangeFilter extends ChangeFilter {
                 // This is not a newly created path.
                 continue
             }
+            const completePath = (dotPath || []).join("/")
+
             const afterAtPath = objectPath.get(
                 change.after as object,
                 dotPath
-                    ? afterPath
-                          .replace(new RegExp("^" + dotPath.join("/")), "")
-                          .replace(/\//g, ".")
+                    ? afterPath.slice( // Remove the path from the start of the string
+                          afterPath.indexOf(completePath) + completePath.length,
+                      )
                     : afterPath.replace(/\//g, "."),
             )
             if (afterAtPath === undefined || afterAtPath === null) {

--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -157,7 +157,8 @@ export class CreatedChangeFilter extends ChangeFilter {
             const afterAtPath = objectPath.get(
                 change.after as object,
                 dotPath
-                    ? afterPath.slice( // Remove the path from the start of the string
+                    ? afterPath.slice(
+                          // Remove the path from the start of the string
                           afterPath.indexOf(completePath) + completePath.length,
                       )
                     : afterPath.replace(/\//g, "."),

--- a/tests/driver/ChangeObserver/CreatedChangeFilter.test.ts
+++ b/tests/driver/ChangeObserver/CreatedChangeFilter.test.ts
@@ -187,4 +187,31 @@ describe("CreatedChangeFilter", () => {
             expect(createdChangeEvents).toEqual(expectedChangeEvents)
         },
     )
+
+    test("firestore created change event with regex special characters", () => {
+        const filter = new CreatedChangeFilter("cars/{carName}")
+
+        // When we observe for created events from a change;
+        const createdChangeEvents = filter.changeEvents(
+            {
+                after: { name: "model t" },
+                delta: { name: "model t" },
+            },
+            ["cars", "car-with-unusual-suffix+0000"],
+        )
+
+        // Then we should get the expected Created change events.
+        expect(createdChangeEvents).toEqual([
+            {
+                parameters: {
+                    carName: "car-with-unusual-suffix+0000",
+                },
+                change: {
+                    after: { name: "model t" },
+                    delta: { name: "model t" },
+                },
+                path: "cars/car-with-unusual-suffix+0000",
+            },
+        ])
+    })
 })


### PR DESCRIPTION
The on created trigger was not working in cases where the document being created was included special regex characters in the path (i.e. a `+`).

This was because of some code that is used for RTDB and Firestore which tries to find the changed document. For firestore, we don't look up the nested field, only the root level of the document, so when we call `get(data, path)`, we expect path to be `''` (i.e. get the root object). Instead of this, it was passing the full path of the object due to the failing regex, which meant the trigger was never called. 