### PR TITLE
Implement get() using FieldPath for DocumentSnapshot

### DIFF
--- a/src/driver/Firestore/InProcessFirestoreDocumentSnapshot.ts
+++ b/src/driver/Firestore/InProcessFirestoreDocumentSnapshot.ts
@@ -1,3 +1,5 @@
+import { cloneDeep, get } from "lodash"
+import { objGet } from "../../util/objPath"
 import { stripFirestoreMeta } from "../../util/stripMeta"
 import { IFieldPath } from "./FieldPath"
 import {
@@ -49,9 +51,22 @@ export class InProcessFirestoreDocumentSnapshot
     }
 
     get(fieldPath: string | IFieldPath): any {
-        throw new Error(
-            "InProcessFirestoreDocumentSnapshot.get not implemented",
-        )
+        if (this.value) {
+            if (typeof fieldPath === "string") {
+                if (!/^[^*~/[\]]+$/.test(fieldPath)) {
+                    throw new Error(
+                        `Error: Paths can't be empty and must not contain
+                        "*~/[]".`,
+                    )
+                }
+                return cloneDeep(get(this.value, fieldPath))
+            }
+            const segments = fieldPath.segments
+            if (segments) {
+                return cloneDeep(objGet(this.value, segments))
+            }
+        }
+        return {}
     }
 
     isEqual(other: IFirestoreDocumentSnapshot): boolean {

--- a/tests/driver/Firestore/InProcessFirestoreDocumentSnapshot.get.test.ts
+++ b/tests/driver/Firestore/InProcessFirestoreDocumentSnapshot.get.test.ts
@@ -1,14 +1,12 @@
 import {
-    InProcessFirestore,
-    InProcessFirestoreDocumentSnapshot,
-} from "../../../dist"
-import { FieldPath } from "../../../dist/driver/Firestore/FieldPath"
-import {
     IFirestore,
     IFirestoreDocRef,
     IFirestoreDocumentData,
+    InProcessFirestore,
     InProcessFirestoreDocRef,
+    InProcessFirestoreDocumentSnapshot,
 } from "../../../src"
+import { FieldPath } from "../../../src/driver/Firestore/FieldPath"
 
 describe("InProcessFirestoreDocumentSnapshot get", () => {
     test("simple field", async () => {
@@ -79,9 +77,7 @@ describe("InProcessFirestoreDocumentSnapshot get", () => {
         )
 
         const valueUsFromString = snapshot.get(pathUs)
-        const valueUsFromObject = snapshot.get(
-            new FieldPath(pathUs.split(".")),
-        )
+        const valueUsFromObject = snapshot.get(new FieldPath(pathUs.split(".")))
 
         const valueUndefinedFromString = snapshot.get(pathUndefined)
         const valueUndefinedFromObject = snapshot.get(

--- a/tests/driver/Firestore/InProcessFirestoreDocumentSnapshot.get.test.ts
+++ b/tests/driver/Firestore/InProcessFirestoreDocumentSnapshot.get.test.ts
@@ -1,0 +1,112 @@
+import {
+    InProcessFirestore,
+    InProcessFirestoreDocumentSnapshot,
+} from "../../../dist"
+import { FieldPath } from "../../../dist/driver/Firestore/FieldPath"
+import {
+    IFirestore,
+    IFirestoreDocRef,
+    IFirestoreDocumentData,
+    InProcessFirestoreDocRef,
+} from "../../../src"
+
+describe("InProcessFirestoreDocumentSnapshot get", () => {
+    test("simple field", async () => {
+        // Given there is a snapshot;
+        const snapshot = createSnapshot({
+            someField: 5,
+        })
+
+        // When we get the value of the field path
+        const pathString = "someField"
+        const valueFromPathString = snapshot.get(pathString)
+        const valueFromPathObject = snapshot.get(
+            new FieldPath(pathString.split(".")),
+        )
+
+        // Then we should get the expected field value
+        expect(valueFromPathString).toEqual(5)
+        expect(valueFromPathString).toEqual(valueFromPathObject)
+    })
+
+    test("missing field", async () => {
+        // Given there is a snapshot;
+        const snapshot = createSnapshot({})
+
+        // When we get the value of the field path
+        const pathString = "someField"
+        const valueFromPathString = snapshot.get(pathString)
+        const valueFromPathObject = snapshot.get(
+            new FieldPath(pathString.split(".")),
+        )
+
+        // Then we should get the expected field value
+        expect(valueFromPathString).toBeUndefined()
+        expect(valueFromPathString).toEqual(valueFromPathObject)
+    })
+
+    test("invalid field throws error", async () => {
+        // Given there is a snapshot;
+        const snapshot = createSnapshot({})
+
+        // When we use invalid path string
+        const pathString = ""
+        const getValueFromPathString = () => snapshot.get(pathString)
+
+        // Then we should get an error
+        expect(getValueFromPathString).toThrowError()
+    })
+
+    test("complex field with arrays", async () => {
+        // Given there is a deeply nested snapshot with an array
+        const snapshot = createSnapshot({
+            foo: {
+                bar: [
+                    { baz: "free", bax: { bb: "join" } },
+                    { baz: "trade", bax: { bb: "us" } },
+                ],
+            },
+        })
+
+        // When we get the value of the field paths
+        const pathJoin = "foo.bar.0.bax.bb"
+        const pathUs = "foo.bar.1.bax.bb"
+        const pathUndefined = "foo.bar.2.bax.bb"
+
+        const valueJoinFromString = snapshot.get(pathJoin)
+        const valueJoinFromObject = snapshot.get(
+            new FieldPath(pathJoin.split(".")),
+        )
+
+        const valueUsFromString = snapshot.get(pathUs)
+        const valueUsFromObject = snapshot.get(
+            new FieldPath(pathUs.split(".")),
+        )
+
+        const valueUndefinedFromString = snapshot.get(pathUndefined)
+        const valueUndefinedFromObject = snapshot.get(
+            new FieldPath(pathUndefined.split(".")),
+        )
+
+        // Then we should get the expected field values
+        expect(valueJoinFromString).toEqual("join")
+        expect(valueUsFromString).toEqual("us")
+        expect(valueUndefinedFromString).toBeUndefined()
+        expect(valueJoinFromString).toEqual(valueJoinFromObject)
+        expect(valueUsFromString).toEqual(valueUsFromObject)
+        expect(valueUndefinedFromString).toEqual(valueUndefinedFromObject)
+    })
+
+    function createSnapshot(
+        value: IFirestoreDocumentData,
+        collection: string = "someCollection",
+        key: string = "68e50d59-2c03-4779-b14f-150ba25dc7a9",
+    ) {
+        const fs: IFirestore & InProcessFirestore = new InProcessFirestore()
+        const ref = new InProcessFirestoreDocRef(
+            `${collection}/${key}`,
+            fs as any,
+        ) as IFirestoreDocRef
+        return new InProcessFirestoreDocumentSnapshot(key, true, ref, value)
+    }
+})


### PR DESCRIPTION
Currently the data can be read from `DocumentSnapshot` using `.data()`.
```ts
const snapshot = await firestore().collection('example').doc('document').get()
const data = snapshot.data()
const fieldValue = data?.fieldWeWant?.deeperField
```

However, sometimes it's easier to use a field path in order to read a specific field. This PR implements `get()` on DocumentSnapshot objects for such cases.
```ts
const snapshot = await firestore().collection('example').doc('document').get()
const fieldPath = 'fieldWeWant.deeperField'
const fieldValue = snapshot.get(fieldPath)
```