### PR TITLE
Remove circular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "0.28.10",
+  "version": "0.28.11",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -1,8 +1,4 @@
 import _ from "lodash"
-import {
-    InProcessFirestore,
-    InProcessFirestoreDocRef,
-} from "./InProcessFirestore"
 import { JsonValue } from "../../util/json"
 import { stripMeta } from "../../util/stripMeta"
 import {
@@ -25,6 +21,10 @@ import {
     IFirestoreDocumentData,
     IFirestoreDocumentSnapshot,
 } from "./IFirestore"
+import {
+    InProcessFirestore,
+    InProcessFirestoreDocRef,
+} from "./InProcessFirestore"
 import { InProcessFirestoreDocumentSnapshot } from "./InProcessFirestoreDocumentSnapshot"
 
 export function makeFirestoreChangeObserver(

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -1,5 +1,8 @@
 import _ from "lodash"
-import { InProcessFirestore, InProcessFirestoreDocRef } from "../.."
+import {
+    InProcessFirestore,
+    InProcessFirestoreDocRef,
+} from "./InProcessFirestore"
 import { JsonValue } from "../../util/json"
 import { stripMeta } from "../../util/stripMeta"
 import {


### PR DESCRIPTION
## Overview
There was a circular dependency that was causing issues:
```
(!) Circular dependencies
node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/FirestoreChangeObserver.js -> node_modules/ts-firebase-driver-testing/dist/index.js -> node_modules/ts-firebase-driver-testing/dist/driver/InProcessFirebaseDriver.js -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js
```

Note: there are still 2 that exist:
```
(!) Circular dependencies
node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/FirestoreChangeObserver.js -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js
node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/FirestoreChangeObserver.js -> /Users/michaelsive/Development/invest-platform/packages/firebase-driver/node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js?commonjs-proxy -> node_modules/ts-firebase-driver-testing/dist/driver/Firestore/InProcessFirestore.js
```