### PR TITLE
Support firestore 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "0.28.11",
+  "version": "1.0.0",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
@@ -45,8 +45,6 @@ export interface IFirebaseRealtimeDatabaseQuery {
 
 export interface IFirebaseRealtimeDatabaseRef
     extends IFirebaseRealtimeDatabaseQuery {
-    readonly path: string
-
     child(path: string): IFirebaseRealtimeDatabaseRef
 
     push(value?: any): IFirebaseRealtimeDatabaseRef


### PR DESCRIPTION
Updates for support for the latest version of dependencies used by [firebase-admin](https://github.com/firebase/firebase-admin-node/releases/tag/v9.8.0)

Solving

```
Type '() => Database' is not assignable to type '() => IFirebaseRealtimeDatabase'.
        Call signature return types 'Database' and 'IFirebaseRealtimeDatabase' are incompatible.
          The types returned by 'ref(...)' are incompatible between these types.
            Property 'path' is missing in type 'Reference' but required in type 'IFirebaseRealtimeDatabaseRef'.

    12     realTimeDatabase(): admin.database.Database {
```