### PR TITLE
Add support for not equals operation in queries

### DIFF
--- a/src/driver/Firestore/IFirestore.ts
+++ b/src/driver/Firestore/IFirestore.ts
@@ -23,6 +23,7 @@ export interface IReadOptions {
 
 export type FirestoreWhereFilterOp =
     | "<"
+    | "!="
     | "<="
     | "=="
     | ">="

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -420,6 +420,14 @@ export class InProcessFirestoreQuery implements IFirestoreQuery {
                     )
                 }
                 break
+            case "!=":
+                filter = (idItem) => {
+                    return (
+                        String(objGet(idItem.item, fieldObjPath)) !==
+                        String(value)
+                    )
+                }
+                break
             case ">=":
                 InProcessFirestoreQuery.enforceSingleFieldRangeFilter(
                     newQuery,

--- a/tests/driver/Firestore/InProcessFirestore.where.basic.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.where.basic.test.ts
@@ -161,6 +161,44 @@ describe("InProcessFirestore querying with where", () => {
         ])
     })
 
+    test("where != number", async () => {
+        // Given a collection of docs with differing values in a field;
+        firestore.resetStorage({
+            animals: {
+                tiger: {
+                    name: "tiger",
+                    popularityRating: 5,
+                },
+                hyena: {
+                    name: "hyena",
+                    popularityRating: 2,
+                },
+                lion: {
+                    name: "lion",
+                    popularityRating: 3,
+                },
+                bear: {
+                    name: "bear",
+                    popularityRating: 3,
+                },
+            },
+        })
+
+        // When we query docs by that field;
+        const result = await firestore
+            .collection("animals")
+            .where("popularityRating", "!=", 3)
+            .get()
+
+        // Then we should get the correct results.
+        expect(result.docs).toHaveLength(2)
+        expect(result.docs.map((doc) => doc.id)).toEqual(["tiger", "hyena"])
+        expect(result.docs.map((doc) => doc.data())).toEqual([
+            { name: "tiger", popularityRating: 5 },
+            { name: "hyena", popularityRating: 2 },
+        ])
+    })
+
     test("where < number", async () => {
         // Given a collection of docs with differing values in a field;
         firestore.resetStorage({


### PR DESCRIPTION
Add support for not equals operation in queries.

This resolves the following error when using `!=` in a query
 ```
Error: Unknown Firestore where operator !=
   at InProcessFirestoreCollectionRef.where
``` 