### PR TITLE
fix/Send PubSub message correctly and with attributes and context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/FirebaseDriver.ts
+++ b/src/driver/FirebaseDriver.ts
@@ -41,8 +41,12 @@ export interface IPubSubTopic {
     publisher: IPubSubPublisher
 }
 
+export interface IAttributes {
+    [key: string]: string
+}
+
 export interface IPubSubPublisher {
-    publish(data: Buffer): Promise<any>
+    publish(data: Buffer, attributes?: IAttributes): Promise<any>
 }
 
 export interface IFirebaseBuilderPubSub {

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -59,7 +59,10 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
         [key: string]: Array<CloudFunction<any>>
     } = {}
 
-    constructor(private readonly jobs: IAsyncJobs) {}
+    constructor(
+        private readonly jobs: IAsyncJobs,
+        private readonly now: () => Date = () => new Date(),
+    ) {}
 
     schedule(schedule: string): InProcessFirebaseScheduleBuilder {
         return new InProcessFirebaseScheduleBuilder()
@@ -86,7 +89,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
                     const message = new PubSubMessage(data, attributes ?? {})
                     resolve(
                         handler(message, {
-                            timestamp: new Date().toISOString(),
+                            timestamp: this.now().toISOString(),
                         }),
                     )
                 }, 1),

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -1,6 +1,7 @@
 import { IAsyncJobs } from "../AsyncJobs"
 import {
     CloudFunction,
+    IAttributes,
     IFirebaseBuilderPubSub,
     IFirebaseScheduleBuilder,
     IFirebaseTopicBuilder,
@@ -11,6 +12,7 @@ import {
 import {
     IFirebaseEventContext,
     IPubSubMessage,
+    PubSubMessage,
 } from "../RealtimeDatabase/IFirebaseRealtimeDatabase"
 
 export class InProcessFirebaseScheduleBuilder
@@ -74,14 +76,19 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
         this.subscriptions[topicName].push(handler)
     }
 
-    _publish(topicName: string, data: Buffer): void {
+    _publish(topicName: string, data: Buffer, attributes?: IAttributes): void {
         if (!this.subscriptions[topicName]) {
             return
         }
         for (const handler of this.subscriptions[topicName]) {
             const job = new Promise((resolve) =>
                 setTimeout(async () => {
-                    resolve(handler(JSON.parse(data.toString())))
+                    const message = new PubSubMessage(data, attributes ?? {})
+                    resolve(
+                        handler(message, {
+                            timestamp: new Date().toISOString(),
+                        }),
+                    )
                 }, 1),
             )
             this.jobs.pushJob(job)
@@ -93,8 +100,8 @@ class InProcessPubSubPublisher implements IPubSubPublisher {
     constructor(private readonly topic: InProcessFirebasePubSubTopic) {}
 
     // @ts-ignore
-    publish(data: Buffer): Promise<void> {
-        this.topic._publish(data)
+    publish(data: Buffer, attributes?: Attributes): Promise<void> {
+        this.topic._publish(data, attributes)
     }
 }
 
@@ -108,8 +115,8 @@ class InProcessFirebasePubSubTopic implements IPubSubTopic {
         this.publisher = new InProcessPubSubPublisher(this)
     }
 
-    _publish(data: Buffer) {
-        this.pubSub._publish(this.name, data)
+    _publish(data: Buffer, attributes?: IAttributes) {
+        this.pubSub._publish(this.name, data, attributes)
     }
 }
 

--- a/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase.ts
@@ -1,3 +1,5 @@
+import { IAttributes } from "../FirebaseDriver"
+
 export interface IFirebaseRealtimeDatabase {
     ref(path?: string): IFirebaseRealtimeDatabaseRef
 }
@@ -82,4 +84,34 @@ export interface IPubSubMessage {
     readonly attributes: { [key: string]: string }
     readonly json: any
     toJSON(): any
+}
+
+export class PubSubMessage implements IPubSubMessage {
+    /**
+     * The data payload of this message object as a base64-encoded string.
+     */
+    readonly data: string
+    /**
+     * User-defined attributes published with the message, if any.
+     */
+    readonly attributes: {
+        [key: string]: string
+    }
+    constructor(data: Buffer, attributes: IAttributes) {
+        this.data = data.toString("base64")
+        this.attributes = attributes
+    }
+    /**
+     * The JSON data payload of this message object, if any.
+     */
+    get json(): any {
+        return JSON.parse(Buffer.from(this.data, "base64").toString("utf-8"))
+    }
+    /**
+     * Returns a JSON-serializable representation of this object.
+     * @return A JSON-serializable representation of this object.
+     */
+    toJSON(): any {
+        return this.json
+    }
 }

--- a/tests/driver/PubSub/InProcessFirebasePubSubTopic.publish.test.ts
+++ b/tests/driver/PubSub/InProcessFirebasePubSubTopic.publish.test.ts
@@ -1,0 +1,65 @@
+import {
+    InProcessFirebaseBuilderPubSub,
+    InProcessFirebasePubSubCl,
+} from "../../../src"
+import { AsyncJobs } from "../../../src/driver/AsyncJobs"
+import { IPubSubMessage } from "../../../src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase"
+
+describe("InProcessFirebasePubSubTopic publisher.publish", () => {
+    test("Publishes a message to a topic with attributes and context.", async () => {
+        // Given the mocks
+        const topic = "Test-Topic"
+        const asyncJobs = new AsyncJobs()
+        const dateMock = jest.fn()
+
+        // Given the time is
+        dateMock.mockReturnValue(
+            new Date(Date.parse("2021-05-25T12:00:00.000Z")),
+        )
+
+        // Given the topic builder under test
+        const pubSubBuilder = new InProcessFirebaseBuilderPubSub(
+            asyncJobs,
+            dateMock,
+        )
+        const topicBuilder = pubSubBuilder.topic(topic)
+
+        // Given the test message and attributes
+        const testMessage = {
+            foo: "bah",
+            theBatGoes: ["moo", 1, null],
+        }
+        const testAttributes = {
+            flavour: "chocolate",
+        }
+
+        // Given a function is subscribed to the topic
+        const subFunc = jest
+            .fn()
+            .mockImplementation((message: IPubSubMessage, context: any) => {
+                // Which validates its inputs
+                expect(context.timestamp).toStrictEqual(
+                    "2021-05-25T12:00:00.000Z",
+                )
+                expect(message.json).toStrictEqual(testMessage)
+                expect(message.attributes).toStrictEqual(testAttributes)
+            })
+        topicBuilder.onPublish(subFunc)
+
+        // Given we have a pubsub client
+        const publisher = new InProcessFirebasePubSubCl(pubSubBuilder)
+
+        // When we publish a message to it, it does the subFunc does not catch any errors
+        await publisher
+            .topic(topic)
+            .publisher.publish(
+                Buffer.from(JSON.stringify(testMessage)),
+                testAttributes,
+            )
+
+        await asyncJobs.jobsComplete()
+
+        // And the subFunc has been called
+        expect(subFunc).toHaveBeenCalled()
+    })
+})

--- a/tests/driver/PubSub/PubSubMessage.test.ts
+++ b/tests/driver/PubSub/PubSubMessage.test.ts
@@ -1,0 +1,35 @@
+import { PubSubMessage } from "../../../src/driver/RealtimeDatabase/IFirebaseRealtimeDatabase"
+
+describe("PubSubMessage", () => {
+    test("Stores and returns a buffer", () => {
+        // Given the buffer
+        const testObj = {
+            foo: "bar",
+        }
+        const buffer = Buffer.from(JSON.stringify(testObj))
+
+        // When we build a message
+        const message = new PubSubMessage(buffer, {})
+
+        // We can retrieve it
+        expect(message.json).toStrictEqual(testObj)
+        expect(message.toJSON()).toStrictEqual(testObj)
+    })
+
+    test("Stores and returns attributes", () => {
+        // Given the buffer
+        const buffer = Buffer.from("foo")
+
+        // Given the attributes
+        const attributes = {
+            attri: "butes",
+            theDog: "eats butter",
+        }
+
+        // When we build a message
+        const message = new PubSubMessage(buffer, attributes)
+
+        // We can retrieve its attributes
+        expect(message.attributes).toStrictEqual(attributes)
+    })
+})


### PR DESCRIPTION
The pubsub driver has no tests attached to it, and was passing the raw message into the handler. Instead, an object should be passed which has methods to grab the true payload as well as attributes.
The second argument (context) was also missing, and this is also now passed to the hander.