### PR TITLE
fix/add BulkWriter implementation

### DIFF
--- a/src/driver/Firestore/IFirestore.ts
+++ b/src/driver/Firestore/IFirestore.ts
@@ -8,6 +8,7 @@ export interface IFirestore {
         transactionOptions?: { maxAttempts?: number },
     ): Promise<T>
     batch(): IFirestoreWriteBatch
+    bulkWriter(): IFirestoreBulkWriter
     settings(settings: object): void
     collectionGroup(collectionId: string): IFirestoreQuery
     getAll(
@@ -247,4 +248,51 @@ export interface IFirestoreWriteBatch {
     delete(documentRef: IFirestoreDocRef): IFirestoreWriteBatch
 
     commit(): Promise<IFirestoreWriteResult[]>
+}
+
+
+export interface IFirestoreBulkWriter {
+    close(): Promise<void>
+
+    create(
+        documentRef: IFirestoreDocRef,
+        data: IFirestoreDocumentData,
+    ): Promise<IFirestoreWriteResult>
+
+    delete(
+        documentRef: IFirestoreDocRef,
+        precondition?: IPrecondition,
+    ): Promise<IFirestoreWriteResult>
+    
+    flush(): Promise<void>
+    
+    onWriteError(
+        shouldRetryCallback: (error: Error) => boolean
+    ): void
+
+    onWriteResult(
+        callback: (
+          documentRef: IFirestoreDocRef<any>,
+          result: IFirestoreWriteResult
+        ) => void
+    ): void
+
+    set(
+        documentRef: IFirestoreDocRef,
+        data: IFirestoreDocumentData,
+        options?: { merge?: boolean },
+    ): Promise<IFirestoreWriteResult>
+
+    update(
+        documentRef: IFirestoreDocRef,
+        data: IFirestoreDocumentData,
+        precondition?: IPrecondition,
+    ): Promise<IFirestoreWriteResult>
+
+    update(
+        documentRef: IFirestoreDocRef,
+        field: string | IFieldPath,
+        value: any,
+        ...fieldsOrPrecondition: any[]
+    ): Promise<IFirestoreWriteResult>
 }

--- a/src/driver/Firestore/IFirestore.ts
+++ b/src/driver/Firestore/IFirestore.ts
@@ -250,7 +250,6 @@ export interface IFirestoreWriteBatch {
     commit(): Promise<IFirestoreWriteResult[]>
 }
 
-
 export interface IFirestoreBulkWriter {
     close(): Promise<void>
 
@@ -263,24 +262,22 @@ export interface IFirestoreBulkWriter {
         documentRef: IFirestoreDocRef,
         precondition?: IPrecondition,
     ): Promise<IFirestoreWriteResult>
-    
+
     flush(): Promise<void>
-    
-    onWriteError(
-        shouldRetryCallback: (error: Error) => boolean
-    ): void
+
+    onWriteError(shouldRetryCallback: (error: Error) => boolean): void
 
     onWriteResult(
         callback: (
-          documentRef: IFirestoreDocRef<any>,
-          result: IFirestoreWriteResult
-        ) => void
+            documentRef: IFirestoreDocRef<any>,
+            result: IFirestoreWriteResult,
+        ) => void,
     ): void
 
     set(
         documentRef: IFirestoreDocRef,
         data: IFirestoreDocumentData,
-        options?: SetOptions,
+        options?: ISetOptions,
     ): Promise<IFirestoreWriteResult>
 
     update(
@@ -297,8 +294,8 @@ export interface IFirestoreBulkWriter {
     ): Promise<IFirestoreWriteResult>
 }
 
-export interface SetOptions {
-    merge?: boolean,
+export interface ISetOptions {
+    merge?: boolean
     // Not currently implemented
     // mergeFields?: string[],
 }

--- a/src/driver/Firestore/IFirestore.ts
+++ b/src/driver/Firestore/IFirestore.ts
@@ -280,7 +280,7 @@ export interface IFirestoreBulkWriter {
     set(
         documentRef: IFirestoreDocRef,
         data: IFirestoreDocumentData,
-        options?: { merge?: boolean },
+        options?: SetOptions,
     ): Promise<IFirestoreWriteResult>
 
     update(
@@ -295,4 +295,10 @@ export interface IFirestoreBulkWriter {
         value: any,
         ...fieldsOrPrecondition: any[]
     ): Promise<IFirestoreWriteResult>
+}
+
+export interface SetOptions {
+    merge?: boolean,
+    // Not currently implemented
+    // mergeFields?: string[],
 }

--- a/src/driver/Firestore/IFirestore.ts
+++ b/src/driver/Firestore/IFirestore.ts
@@ -297,5 +297,5 @@ export interface IFirestoreBulkWriter {
 export interface ISetOptions {
     merge?: boolean
     // Not currently implemented
-    // mergeFields?: string[],
+    mergeFields?: string[]
 }

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1374,13 +1374,13 @@ class InProcessFirestoreBulkWriter implements IFirestoreBulkWriter {
     
     constructor(op: () => Promise<IFirestoreWriteResult>) {
         this.op = op
-        this.deferred = new Deferred();
+        this.deferred = new Deferred()
     }
 
     // BulkWriter does this Deferred promise logic to give the following functionality:
     // The Promise (from flush()) will never be rejected since the results for each individual operation are conveyed via their individual Promises.
     get promise() {
-        return this.deferred.promise;
+        return this.deferred.promise
     }
 
     onError(error: Error) {
@@ -1407,12 +1407,12 @@ class InProcessFirestoreBulkWriter implements IFirestoreBulkWriter {
         this.promise = new Promise((resolve, reject) => {
             this.resolve = resolve
             this.reject = reject
-        });
+        })
     }
 }
 
 // Swallows errors
 // Source: https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/util.ts#L191
 function silencePromise(promise: Promise<unknown>) {
-    return promise.then(() => { }, () => { });
+    return promise.then(() => { }, () => { })
 }

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1327,6 +1327,12 @@ class InProcessFirestoreBulkWriter implements IFirestoreBulkWriter {
     ): Promise<IFirestoreWriteResult> {
         this.throwIfClosed()
 
+        if (options?.mergeFields) {
+            throw new Error(
+                "InProcessFirestorBulkWriter.set with mergeFields option is not implemented",
+            )
+        }
+
         const bulkWriteOpPromise = this.enqueue(
             async () => await documentRef.set(data, options),
         )

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1433,9 +1433,10 @@ class Deferred {
     }
 }
 
-// Swallows errors
+// Takes a promise and swallows all errors so it never throws if it's not handled (i.e. await or .then() used)
+// Used to ensure WriteOperation completes but result discarded
 // Source: https://github.com/googleapis/nodejs-firestore/blob/master/dev/src/util.ts#L191
-function silencePromise(promise: Promise<unknown>) {
+function silencePromise(promise: Promise<unknown>): Promise<void> {
     return promise.then(
         () => {},
         () => {},

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -8,7 +8,7 @@ describe('In-process Firestore BulkWriter', () => {
     beforeEach(() => {
         db.resetStorage()
     })
-    test('delivers correct functionality', async () =>{
+    test('handles create, delete, set, update operations and flushes successfully', async () =>{
         // Given we have a in-process Firestore DB;
         // And there is some initial data;
         await db

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -1,0 +1,168 @@
+import { InProcessFirestore } from "../../../src"
+import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
+import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
+
+describe('In-process Firestore BulkWriter', () => {
+    const db = new InProcessFirestore()
+
+    beforeEach(() => {
+        db.resetStorage()
+    })
+    test('delivers correct functionality', async () =>{
+                // Given we have a in-process Firestore DB;
+
+                // And there is some initial data;
+                await db
+                    .collection("cities")
+                    .doc("SF")
+                    .set({
+                        name: "San Francisco",
+                        state: "CA",
+                        country: "USA",
+                        capital: false,
+                        population: 860000,
+                    })
+                await db
+                    .collection("cities")
+                    .doc("LA")
+                    .set({
+                        name: "Los Angeles",
+                        state: "LA",
+                        country: "USA",
+                        capital: false,
+                        population: 4000000,
+                    })
+        
+                // When we get a new BulkWriter;
+                const bulkWriter = db.bulkWriter()
+        
+                // And set the value of 'NYC';
+                const nycRef = db.collection("cities").doc("NYC")
+                bulkWriter.set(nycRef, { name: "New York City" })
+        
+                // And update the population of 'SF';
+                const sfRef = db.collection("cities").doc("SF")
+                bulkWriter.update(sfRef, { population: 1000000 })
+        
+                // Add downtown district to SF
+                const nycDistrictsRef = db
+                    .collection("cities")
+                    .doc("NYC")
+                    .collection("districts")
+                    .doc("downtown")
+        
+                bulkWriter.set(nycDistrictsRef, { density: 200 })
+        
+                // Add more details changed during batch
+                bulkWriter.set(nycRef, { name: "New York City", population: 4000000 })
+        
+                // And delete the city 'LA';
+                const laRef = db.collection("cities").doc("LA")
+                bulkWriter.delete(laRef)
+        
+                // When we flush the BulkWriter;
+                await bulkWriter.flush()
+        
+                // And get the data;
+                const newYork = await db
+                    .collection("cities")
+                    .doc("NYC")
+                    .get()
+                const newYorkDistricts = await db
+                    .collection("cities")
+                    .doc("NYC")
+                    .collection("districts")
+                    .doc("downtown")
+                    .get()
+        
+                const sanFrancisco = await db
+                    .collection("cities")
+                    .doc("SF")
+                    .get()
+                const losAngeles = await db
+                    .collection("cities")
+                    .doc("LA")
+                    .get()
+        
+                // Then the data should have been updated correctly.
+                expect(newYork.exists).toBeTruthy()
+                expect(newYork.data()).toEqual({
+                    name: "New York City",
+                    population: 4000000,
+                })
+        
+                expect(newYorkDistricts.exists).toBeTruthy()
+                expect(newYorkDistricts.data()).toEqual({ density: 200 })
+        
+                expect(sanFrancisco.exists).toBeTruthy()
+                expect(sanFrancisco.data()).toEqual({
+                    name: "San Francisco",
+                    state: "CA",
+                    country: "USA",
+                    capital: false,
+                    population: 1000000,
+                })
+        
+                expect(losAngeles.exists).toBeFalsy()
+                expect(losAngeles.data()).toEqual({})
+    })
+
+    test("cannot create existing document in a bulk write", async () => {
+        // Given there is an existing document;
+        await db
+            .collection("animals")
+            .doc("tiger")
+            .set({ description: "stripey" })
+
+        // When we create the same document;
+        let error: Error | null = null
+        try {
+            const bulkWriter = db.bulkWriter()
+            bulkWriter.create(db.doc("/animals/tiger"), {
+                size: "large",
+            })
+
+            await bulkWriter.flush()
+        } catch (err) {
+            error = err
+        }
+
+        // Then the write should fail;
+        expect(error).isFirestoreErrorWithCode(
+            GRPCStatusCode.ALREADY_EXISTS,
+            new RegExp("animals/tiger"),
+        )
+
+        // And the document should not be changed.
+        const snapshot = await db
+            .collection("animals")
+            .doc("tiger")
+            .get()
+        expect(snapshot.exists).toBeTruthy()
+        expect(snapshot.data()).toEqual({ description: "stripey" })
+    })
+
+    test("throws if an undefined field is written", async () => {
+        // Given we have a write batch;
+        const bulkWriter = db.bulkWriter()
+
+        // And we make a change in the batch;
+        const docRef = db.collection("things").doc("thingA")
+        bulkWriter.create(docRef, { foo: "bar", bar: undefined })
+
+        // The commit should throw
+        await expect(bulkWriter.flush()).rejects.toThrowError(FirestoreError)
+
+        // And the db should be empty
+        expect(db.storage).toEqual({})
+    })
+
+    test("throws if calls made after close()", async () => {
+        // Given we have a write batch;
+        const bulkWriter = db.bulkWriter()
+
+        await bulkWriter.close()
+
+        await expect(bulkWriter.flush()).rejects.toThrowError()
+    })
+})

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -1,6 +1,6 @@
-import { InProcessFirestore } from "../../../src"
-import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
-import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
+import { InProcessFirestore } from '../../../src'
+import { GRPCStatusCode } from '../../../src/driver/Common/GRPCStatusCode'
+import { FirestoreError } from '../../../src/driver/Firestore/FirestoreError'
 
 describe('In-process Firestore BulkWriter', () => {
     const db = new InProcessFirestore()
@@ -8,117 +8,197 @@ describe('In-process Firestore BulkWriter', () => {
     beforeEach(() => {
         db.resetStorage()
     })
-    test('handles create, delete, set, update operations and flushes successfully', async () =>{
-        // Given we have a in-process Firestore DB;
-        // And there is some initial data;
-        await db
-            .collection("cities")
-            .doc("SF")
-            .set({
-                name: "San Francisco",
-                state: "CA",
-                country: "USA",
-                capital: false,
-                population: 860000,
-            })
-        await db
-            .collection("cities")
-            .doc("LA")
-            .set({
-                name: "Los Angeles",
-                state: "LA",
-                country: "USA",
-                capital: false,
-                population: 4000000,
-            })
 
-        // When we get a new BulkWriter;
+    test('set operation updates the doc and underlying collections correctly', async () => {
+        // When we get a new BulkWriter
         const bulkWriter = db.bulkWriter()
 
-        // And set the value of 'NYC';
-        const nycRef = db.collection("cities").doc("NYC")
-        bulkWriter.set(nycRef, { name: "New York City" })
-
-        // And update the population of 'SF';
-        const sfRef = db.collection("cities").doc("SF")
-        bulkWriter.update(sfRef, { population: 1000000 })
-
-        // Add downtown district to SF
+        // And set the value of NYC doc
+        const nycRef = db.collection('cities').doc('NYC')
+        bulkWriter.set(nycRef, { name: 'New York City' })
+        
+        // Add downtown district to NYC doc
         const nycDistrictsRef = db
-            .collection("cities")
-            .doc("NYC")
-            .collection("districts")
-            .doc("downtown")
+            .collection('cities')
+            .doc('NYC')
+            .collection('districts')
+            .doc('downtown')
 
         bulkWriter.set(nycDistrictsRef, { density: 200 })
 
-        // Add more details changed during batch
-        bulkWriter.set(nycRef, { name: "New York City", population: 4000000 })
+        // Add more set changes
+        bulkWriter.set(nycRef, { name: 'New York City', population: 4000000 })
 
-        // And delete the city 'LA';
-        const laRef = db.collection("cities").doc("LA")
-        bulkWriter.delete(laRef)
-
-        // When we flush the BulkWriter;
+        // When we flush the BulkWriter
         await bulkWriter.flush()
 
-        // And get the data;
+        // And get the NYC data
         const newYork = await db
-            .collection("cities")
-            .doc("NYC")
+            .collection('cities')
+            .doc('NYC')
             .get()
         const newYorkDistricts = await db
-            .collection("cities")
-            .doc("NYC")
-            .collection("districts")
-            .doc("downtown")
-            .get()
-
-        const sanFrancisco = await db
-            .collection("cities")
-            .doc("SF")
-            .get()
-        const losAngeles = await db
-            .collection("cities")
-            .doc("LA")
+            .collection('cities')
+            .doc('NYC')
+            .collection('districts')
+            .doc('downtown')
             .get()
 
         // Then the data should have been updated correctly.
         expect(newYork.exists).toBeTruthy()
         expect(newYork.data()).toEqual({
-            name: "New York City",
+            name: 'New York City',
             population: 4000000,
         })
 
         expect(newYorkDistricts.exists).toBeTruthy()
         expect(newYorkDistricts.data()).toEqual({ density: 200 })
+    })
 
-        expect(sanFrancisco.exists).toBeTruthy()
-        expect(sanFrancisco.data()).toEqual({
-            name: "San Francisco",
-            state: "CA",
-            country: "USA",
+    test('set operation with merge flag replaces correct doc fields', async () => {
+        // given some doc with data
+        const docRef = db
+            .collection('cities')
+            .doc('SF')
+        
+        await docRef.set({
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            capital: false,
+            population: 860000,
+        })
+
+        // when we get a new BulkWriter
+        const bulkWriter = db.bulkWriter()
+
+        // and we set a field with the merge flag
+        bulkWriter.set(
+            docRef,
+            { population : 1000000 },
+            { merge: true },
+        )
+        
+        // when we flush
+        await bulkWriter.flush()
+
+        // we expect the doc to be updated
+        const doc = await docRef.get()
+        expect(doc.data()).toEqual({
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
             capital: false,
             population: 1000000,
         })
-
-        expect(losAngeles.exists).toBeFalsy()
-        expect(losAngeles.data()).toEqual({})
     })
 
-    test("cannot create existing document in a bulk write", async () => {
+    test('update operation updates the doc fields correctly', async () => {
+        // given an existing doc
+        const docRef = db
+            .collection('cities')
+            .doc('SF')
+        
+        await docRef.set({
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            capital: false,
+            population: 860000,
+        })
+
+        // When we get a new BulkWriter
+        const bulkWriter = db.bulkWriter()
+
+        // And update the population of SF;
+        bulkWriter.update(docRef, { population: 1000000 })
+
+        // when we flush
+        await bulkWriter.flush()
+
+        // we expect the doc to be updated
+        const doc = await docRef.get()
+        expect(doc.data()).toEqual({
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            capital: false,
+            population: 1000000,
+        })
+    })
+
+    test('create operation creates the doc correctly', async () => {
+        // When we get a new BulkWriter
+        const bulkWriter = db.bulkWriter()
+        
+        // And create a doc with data
+        const docRef = db
+            .collection('cities')
+            .doc('SF')
+        
+        bulkWriter.create(docRef, {
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            capital: false,
+            population: 860000,
+        })
+
+        // when we flush
+        await bulkWriter.flush()
+
+        // we expect the doc to be created
+        const doc = await docRef.get()
+        expect(doc.data()).toEqual({
+            name: 'San Francisco',
+            state: 'CA',
+            country: 'USA',
+            capital: false,
+            population: 860000,
+        })
+    })
+
+    test('delete operation deletes the doc correctly', async () => {
+        // given an existing doc
+        const docRef = db
+            .collection('cities')
+            .doc('LA')
+        
+        await docRef.set({
+            name: 'Los Angeles',
+            state: 'LA',
+            country: 'USA',
+            capital: false,
+            population: 4000000,
+        })
+
+        // When we get a new BulkWriter
+        const bulkWriter = db.bulkWriter()
+
+        // And delete the LA doc
+        bulkWriter.delete(docRef)
+
+        // when we flush
+        await bulkWriter.flush()
+
+        // we expect the doc to have been deleted
+        const doc = await docRef.get()
+        expect(doc.exists).toBeFalsy()
+        expect(doc.data()).toEqual({})
+    })
+    test('cannot create existing document in a bulk write', async () => {
         // Given there is an existing document;
         await db
-            .collection("animals")
-            .doc("tiger")
-            .set({ description: "stripey" })
+            .collection('animals')
+            .doc('tiger')
+            .set({ description: 'stripey' })
 
         // When we create the same document;
         let error: Error | null = null
         const bulkWriter = db.bulkWriter()
         
-        bulkWriter.create(db.doc("/animals/tiger"), {
-            size: "large",
+        bulkWriter.create(db.doc('/animals/tiger'), {
+            size: 'large',
         }).catch((createError) => {
             error = createError
         })
@@ -128,27 +208,27 @@ describe('In-process Firestore BulkWriter', () => {
         // Then the write should fail;
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
-            new RegExp("animals/tiger"),
+            new RegExp('animals/tiger'),
         )
 
         // And the document should not be changed.
         const snapshot = await db
-            .collection("animals")
-            .doc("tiger")
+            .collection('animals')
+            .doc('tiger')
             .get()
         expect(snapshot.exists).toBeTruthy()
-        expect(snapshot.data()).toEqual({ description: "stripey" })
+        expect(snapshot.data()).toEqual({ description: 'stripey' })
     })
 
-    test("throws if an undefined field is written", async () => {
+    test('throws if an undefined field is written', async () => {
         // Given we have a write writer
         const bulkWriter = db.bulkWriter()
 
         let bulkWriterCreateError = null
         // And we make a change in the batch
-        const docRef = db.collection("things").doc("thingA")
+        const docRef = db.collection('things').doc('thingA')
         bulkWriter
-            .create(docRef, { foo: "bar", bar: undefined })
+            .create(docRef, { foo: 'bar', bar: undefined })
             .catch((createError) => {
                 bulkWriterCreateError = createError
             })
@@ -163,7 +243,7 @@ describe('In-process Firestore BulkWriter', () => {
         expect(db.storage).toEqual({})
     })
 
-    test("throws if calls made after close()", async () => {
+    test('throws if calls made after close()', async () => {
         // Given we have a write batch;
         const bulkWriter = db.bulkWriter()
 

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -1,53 +1,53 @@
-import { InProcessFirestore } from '../../../src'
-import { GRPCStatusCode } from '../../../src/driver/Common/GRPCStatusCode'
-import { FirestoreError } from '../../../src/driver/Firestore/FirestoreError'
+import { InProcessFirestore } from "../../../src"
+import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
+import { FirestoreError } from "../../../src/driver/Firestore/FirestoreError"
 
-describe('In-process Firestore BulkWriter', () => {
+describe("In-process Firestore BulkWriter", () => {
     const db = new InProcessFirestore()
 
     beforeEach(() => {
         db.resetStorage()
     })
 
-    test('set operation updates the doc and underlying collections correctly', async () => {
+    test("set operation updates the doc and underlying collections correctly", async () => {
         // When we get a new BulkWriter
         const bulkWriter = db.bulkWriter()
 
         // And set the value of NYC doc
-        const nycRef = db.collection('cities').doc('NYC')
-        bulkWriter.set(nycRef, { name: 'New York City' })
-        
+        const nycRef = db.collection("cities").doc("NYC")
+        bulkWriter.set(nycRef, { name: "New York City" })
+
         // Add downtown district to NYC doc
         const nycDistrictsRef = db
-            .collection('cities')
-            .doc('NYC')
-            .collection('districts')
-            .doc('downtown')
+            .collection("cities")
+            .doc("NYC")
+            .collection("districts")
+            .doc("downtown")
 
         bulkWriter.set(nycDistrictsRef, { density: 200 })
 
         // Add more set changes
-        bulkWriter.set(nycRef, { name: 'New York City', population: 4000000 })
+        bulkWriter.set(nycRef, { name: "New York City", population: 4000000 })
 
         // When we flush the BulkWriter
         await bulkWriter.flush()
 
         // And get the NYC data
         const newYork = await db
-            .collection('cities')
-            .doc('NYC')
+            .collection("cities")
+            .doc("NYC")
             .get()
         const newYorkDistricts = await db
-            .collection('cities')
-            .doc('NYC')
-            .collection('districts')
-            .doc('downtown')
+            .collection("cities")
+            .doc("NYC")
+            .collection("districts")
+            .doc("downtown")
             .get()
 
         // Then the data should have been updated correctly.
         expect(newYork.exists).toBeTruthy()
         expect(newYork.data()).toEqual({
-            name: 'New York City',
+            name: "New York City",
             population: 4000000,
         })
 
@@ -55,16 +55,14 @@ describe('In-process Firestore BulkWriter', () => {
         expect(newYorkDistricts.data()).toEqual({ density: 200 })
     })
 
-    test('set operation with merge flag replaces correct doc fields', async () => {
+    test("set operation with merge flag replaces correct doc fields", async () => {
         // given some doc with data
-        const docRef = db
-            .collection('cities')
-            .doc('SF')
-        
+        const docRef = db.collection("cities").doc("SF")
+
         await docRef.set({
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 860000,
         })
@@ -73,36 +71,30 @@ describe('In-process Firestore BulkWriter', () => {
         const bulkWriter = db.bulkWriter()
 
         // and we set a field with the merge flag
-        bulkWriter.set(
-            docRef,
-            { population : 1000000 },
-            { merge: true },
-        )
-        
+        bulkWriter.set(docRef, { population: 1000000 }, { merge: true })
+
         // when we flush
         await bulkWriter.flush()
 
         // we expect the doc to be updated
         const doc = await docRef.get()
         expect(doc.data()).toEqual({
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 1000000,
         })
     })
 
-    test('update operation updates the doc fields correctly', async () => {
+    test("update operation updates the doc fields correctly", async () => {
         // given an existing doc
-        const docRef = db
-            .collection('cities')
-            .doc('SF')
-        
+        const docRef = db.collection("cities").doc("SF")
+
         await docRef.set({
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 860000,
         })
@@ -119,27 +111,25 @@ describe('In-process Firestore BulkWriter', () => {
         // we expect the doc to be updated
         const doc = await docRef.get()
         expect(doc.data()).toEqual({
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 1000000,
         })
     })
 
-    test('create operation creates the doc correctly', async () => {
+    test("create operation creates the doc correctly", async () => {
         // When we get a new BulkWriter
         const bulkWriter = db.bulkWriter()
-        
+
         // And create a doc with data
-        const docRef = db
-            .collection('cities')
-            .doc('SF')
-        
+        const docRef = db.collection("cities").doc("SF")
+
         bulkWriter.create(docRef, {
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 860000,
         })
@@ -150,24 +140,22 @@ describe('In-process Firestore BulkWriter', () => {
         // we expect the doc to be created
         const doc = await docRef.get()
         expect(doc.data()).toEqual({
-            name: 'San Francisco',
-            state: 'CA',
-            country: 'USA',
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
             capital: false,
             population: 860000,
         })
     })
 
-    test('delete operation deletes the doc correctly', async () => {
+    test("delete operation deletes the doc correctly", async () => {
         // given an existing doc
-        const docRef = db
-            .collection('cities')
-            .doc('LA')
-        
+        const docRef = db.collection("cities").doc("LA")
+
         await docRef.set({
-            name: 'Los Angeles',
-            state: 'LA',
-            country: 'USA',
+            name: "Los Angeles",
+            state: "LA",
+            country: "USA",
             capital: false,
             population: 4000000,
         })
@@ -186,64 +174,66 @@ describe('In-process Firestore BulkWriter', () => {
         expect(doc.exists).toBeFalsy()
         expect(doc.data()).toEqual({})
     })
-    test('cannot create existing document in a bulk write', async () => {
+    test("cannot create existing document in a bulk write", async () => {
         // Given there is an existing document
         await db
-            .collection('animals')
-            .doc('tiger')
-            .set({ description: 'stripey' })
+            .collection("animals")
+            .doc("tiger")
+            .set({ description: "stripey" })
 
         // When we create the same document
         let error: Error | null = null
         const bulkWriter = db.bulkWriter()
-        
-        bulkWriter.create(db.doc('/animals/tiger'), {
-            size: 'large',
-        }).catch((createError) => {
-            error = createError
-        })
+
+        bulkWriter
+            .create(db.doc("/animals/tiger"), {
+                size: "large",
+            })
+            .catch((createError) => {
+                error = createError
+            })
 
         await bulkWriter.flush()
- 
+
         // Then the write should fail
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
-            new RegExp('animals/tiger'),
+            new RegExp("animals/tiger"),
         )
 
         // And the document should not be changed.
         const snapshot = await db
-            .collection('animals')
-            .doc('tiger')
+            .collection("animals")
+            .doc("tiger")
             .get()
         expect(snapshot.exists).toBeTruthy()
-        expect(snapshot.data()).toEqual({ description: 'stripey' })
+        expect(snapshot.data()).toEqual({ description: "stripey" })
     })
 
-    test('throws if an undefined field is written', async () => {
+    test("throws if an undefined field is written", async () => {
         // Given we have a write writer
         const bulkWriter = db.bulkWriter()
 
         let bulkWriterCreateError = null
         // And we make a change in the batch
-        const docRef = db.collection('things').doc('thingA')
+        const docRef = db.collection("things").doc("thingA")
         bulkWriter
-            .create(docRef, { foo: 'bar', bar: undefined })
+            .create(docRef, { foo: "bar", bar: undefined })
             .catch((createError) => {
                 bulkWriterCreateError = createError
             })
-    
+
         // when we flush the bulk writer
         await bulkWriter.flush()
-        
+
         // we expect the create op to have thrown an error
         expect(bulkWriterCreateError).toBeInstanceOf(FirestoreError)
-        
+
         // And the db should be empty
         expect(db.storage).toEqual({})
     })
 
-    test('throws if calls made after close()', async () => {
+    test("throws if calls made after close()", async () => {
         // Given we have a write batch
         const bulkWriter = db.bulkWriter()
 

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -9,102 +9,101 @@ describe('In-process Firestore BulkWriter', () => {
         db.resetStorage()
     })
     test('delivers correct functionality', async () =>{
-                // Given we have a in-process Firestore DB;
+        // Given we have a in-process Firestore DB;
+        // And there is some initial data;
+        await db
+            .collection("cities")
+            .doc("SF")
+            .set({
+                name: "San Francisco",
+                state: "CA",
+                country: "USA",
+                capital: false,
+                population: 860000,
+            })
+        await db
+            .collection("cities")
+            .doc("LA")
+            .set({
+                name: "Los Angeles",
+                state: "LA",
+                country: "USA",
+                capital: false,
+                population: 4000000,
+            })
 
-                // And there is some initial data;
-                await db
-                    .collection("cities")
-                    .doc("SF")
-                    .set({
-                        name: "San Francisco",
-                        state: "CA",
-                        country: "USA",
-                        capital: false,
-                        population: 860000,
-                    })
-                await db
-                    .collection("cities")
-                    .doc("LA")
-                    .set({
-                        name: "Los Angeles",
-                        state: "LA",
-                        country: "USA",
-                        capital: false,
-                        population: 4000000,
-                    })
-        
-                // When we get a new BulkWriter;
-                const bulkWriter = db.bulkWriter()
-        
-                // And set the value of 'NYC';
-                const nycRef = db.collection("cities").doc("NYC")
-                bulkWriter.set(nycRef, { name: "New York City" })
-        
-                // And update the population of 'SF';
-                const sfRef = db.collection("cities").doc("SF")
-                bulkWriter.update(sfRef, { population: 1000000 })
-        
-                // Add downtown district to SF
-                const nycDistrictsRef = db
-                    .collection("cities")
-                    .doc("NYC")
-                    .collection("districts")
-                    .doc("downtown")
-        
-                bulkWriter.set(nycDistrictsRef, { density: 200 })
-        
-                // Add more details changed during batch
-                bulkWriter.set(nycRef, { name: "New York City", population: 4000000 })
-        
-                // And delete the city 'LA';
-                const laRef = db.collection("cities").doc("LA")
-                bulkWriter.delete(laRef)
-        
-                // When we flush the BulkWriter;
-                await bulkWriter.flush()
-        
-                // And get the data;
-                const newYork = await db
-                    .collection("cities")
-                    .doc("NYC")
-                    .get()
-                const newYorkDistricts = await db
-                    .collection("cities")
-                    .doc("NYC")
-                    .collection("districts")
-                    .doc("downtown")
-                    .get()
-        
-                const sanFrancisco = await db
-                    .collection("cities")
-                    .doc("SF")
-                    .get()
-                const losAngeles = await db
-                    .collection("cities")
-                    .doc("LA")
-                    .get()
-        
-                // Then the data should have been updated correctly.
-                expect(newYork.exists).toBeTruthy()
-                expect(newYork.data()).toEqual({
-                    name: "New York City",
-                    population: 4000000,
-                })
-        
-                expect(newYorkDistricts.exists).toBeTruthy()
-                expect(newYorkDistricts.data()).toEqual({ density: 200 })
-        
-                expect(sanFrancisco.exists).toBeTruthy()
-                expect(sanFrancisco.data()).toEqual({
-                    name: "San Francisco",
-                    state: "CA",
-                    country: "USA",
-                    capital: false,
-                    population: 1000000,
-                })
-        
-                expect(losAngeles.exists).toBeFalsy()
-                expect(losAngeles.data()).toEqual({})
+        // When we get a new BulkWriter;
+        const bulkWriter = db.bulkWriter()
+
+        // And set the value of 'NYC';
+        const nycRef = db.collection("cities").doc("NYC")
+        bulkWriter.set(nycRef, { name: "New York City" })
+
+        // And update the population of 'SF';
+        const sfRef = db.collection("cities").doc("SF")
+        bulkWriter.update(sfRef, { population: 1000000 })
+
+        // Add downtown district to SF
+        const nycDistrictsRef = db
+            .collection("cities")
+            .doc("NYC")
+            .collection("districts")
+            .doc("downtown")
+
+        bulkWriter.set(nycDistrictsRef, { density: 200 })
+
+        // Add more details changed during batch
+        bulkWriter.set(nycRef, { name: "New York City", population: 4000000 })
+
+        // And delete the city 'LA';
+        const laRef = db.collection("cities").doc("LA")
+        bulkWriter.delete(laRef)
+
+        // When we flush the BulkWriter;
+        await bulkWriter.flush()
+
+        // And get the data;
+        const newYork = await db
+            .collection("cities")
+            .doc("NYC")
+            .get()
+        const newYorkDistricts = await db
+            .collection("cities")
+            .doc("NYC")
+            .collection("districts")
+            .doc("downtown")
+            .get()
+
+        const sanFrancisco = await db
+            .collection("cities")
+            .doc("SF")
+            .get()
+        const losAngeles = await db
+            .collection("cities")
+            .doc("LA")
+            .get()
+
+        // Then the data should have been updated correctly.
+        expect(newYork.exists).toBeTruthy()
+        expect(newYork.data()).toEqual({
+            name: "New York City",
+            population: 4000000,
+        })
+
+        expect(newYorkDistricts.exists).toBeTruthy()
+        expect(newYorkDistricts.data()).toEqual({ density: 200 })
+
+        expect(sanFrancisco.exists).toBeTruthy()
+        expect(sanFrancisco.data()).toEqual({
+            name: "San Francisco",
+            state: "CA",
+            country: "USA",
+            capital: false,
+            population: 1000000,
+        })
+
+        expect(losAngeles.exists).toBeFalsy()
+        expect(losAngeles.data()).toEqual({})
     })
 
     test("cannot create existing document in a bulk write", async () => {
@@ -116,17 +115,16 @@ describe('In-process Firestore BulkWriter', () => {
 
         // When we create the same document;
         let error: Error | null = null
-        try {
-            const bulkWriter = db.bulkWriter()
-            bulkWriter.create(db.doc("/animals/tiger"), {
-                size: "large",
-            })
+        const bulkWriter = db.bulkWriter()
+        
+        bulkWriter.create(db.doc("/animals/tiger"), {
+            size: "large",
+        }).catch((createError) => {
+            error = createError
+        })
 
-            await bulkWriter.flush()
-        } catch (err) {
-            error = err
-        }
-
+        await bulkWriter.flush()
+ 
         // Then the write should fail;
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
@@ -143,16 +141,24 @@ describe('In-process Firestore BulkWriter', () => {
     })
 
     test("throws if an undefined field is written", async () => {
-        // Given we have a write batch;
+        // Given we have a write writer
         const bulkWriter = db.bulkWriter()
 
-        // And we make a change in the batch;
+        let bulkWriterCreateError = null
+        // And we make a change in the batch
         const docRef = db.collection("things").doc("thingA")
-        bulkWriter.create(docRef, { foo: "bar", bar: undefined })
-
-        // The commit should throw
-        await expect(bulkWriter.flush()).rejects.toThrowError(FirestoreError)
-
+        bulkWriter
+            .create(docRef, { foo: "bar", bar: undefined })
+            .catch((createError) => {
+                bulkWriterCreateError = createError
+            })
+    
+        // when we flush the bulk writer
+        await bulkWriter.flush()
+        
+        // we expect the create op to have thrown an error
+        expect(bulkWriterCreateError).toBeInstanceOf(FirestoreError)
+        
         // And the db should be empty
         expect(db.storage).toEqual({})
     })

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -110,7 +110,7 @@ describe('In-process Firestore BulkWriter', () => {
         // When we get a new BulkWriter
         const bulkWriter = db.bulkWriter()
 
-        // And update the population of SF;
+        // And update the population of SF
         bulkWriter.update(docRef, { population: 1000000 })
 
         // when we flush
@@ -187,13 +187,13 @@ describe('In-process Firestore BulkWriter', () => {
         expect(doc.data()).toEqual({})
     })
     test('cannot create existing document in a bulk write', async () => {
-        // Given there is an existing document;
+        // Given there is an existing document
         await db
             .collection('animals')
             .doc('tiger')
             .set({ description: 'stripey' })
 
-        // When we create the same document;
+        // When we create the same document
         let error: Error | null = null
         const bulkWriter = db.bulkWriter()
         
@@ -205,7 +205,7 @@ describe('In-process Firestore BulkWriter', () => {
 
         await bulkWriter.flush()
  
-        // Then the write should fail;
+        // Then the write should fail
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
             new RegExp('animals/tiger'),
@@ -244,7 +244,7 @@ describe('In-process Firestore BulkWriter', () => {
     })
 
     test('throws if calls made after close()', async () => {
-        // Given we have a write batch;
+        // Given we have a write batch
         const bulkWriter = db.bulkWriter()
 
         await bulkWriter.close()

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,13 @@
     "semicolon": [true, "never"],
     "member-access": [true, "no-public"],
     "max-classes-per-file": [false, 1],
-    "object-literal-sort-keys": [false]
+    "object-literal-sort-keys": [false],
+    "no-empty": [true, "allow-empty-functions"],
+    "variable-name": {
+      "options": [
+        "allow-leading-underscore"
+      ]
+    }
   },
   "rulesDirectory": []
 }


### PR DESCRIPTION
Currently have `WriteBatch` but not `BulkWriter` implementation (https://googleapis.dev/nodejs/firestore/latest/BulkWriter.html)

I've added some basic core functionality which should be sufficient to drop-in to existing driver testing suites.

It's is however not exhaustive and more complex usages (retries through `onWriteError` etc) are not implemented