### PR TITLE
bump version to v1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
bumped the version to v1.0.4 to release the BulkWriter implementation (https://github.com/freetrade-io/ts-firebase-driver-testing/pull/114)