### PR TITLE
Prevent nested undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1,3 +1,4 @@
+import flatten from "flat"
 import _ from "lodash"
 import {
     CloudFunction,
@@ -752,8 +753,11 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
     private static extractUndefinedFields(
         updateDelta: IFirestoreDocumentData,
     ): string[] {
-        return Object.keys(updateDelta).filter(
-            (path) => updateDelta[path] === undefined,
+        const flattenedUpdateDelta: IFirestoreDocumentData = flatten(
+            updateDelta,
+        )
+        return Object.keys(flattenedUpdateDelta).filter(
+            (path) => flattenedUpdateDelta[path] === undefined,
         )
     }
 

--- a/tests/driver/Firestore/InProcessFirestore.set.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.set.test.ts
@@ -144,6 +144,29 @@ describe("InProcessFirestore set", () => {
             expect(stored.exists).toBe(false)
             expect(stored.data()).toEqual({})
         })
+
+        test("throws with an undefined nested field", async () => {
+            // When we set a new document in a collection, it throws;
+            await expect(
+                firestore
+                    .collection("myCollection")
+                    .doc("thing")
+                    .set({
+                        name: "thing",
+                        good: {
+                            thing: undefined,
+                        },
+                    }),
+            ).rejects.toThrowError(FirestoreError)
+
+            // Then the data should not be stored;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("thing")
+                .get()
+            expect(stored.exists).toBe(false)
+            expect(stored.data()).toEqual({})
+        })
     })
 
     describe(".doc().update()", () => {
@@ -191,6 +214,40 @@ describe("InProcessFirestore set", () => {
                     .update({
                         field2: "new value 2",
                         foo: undefined,
+                        amount: 123,
+                    }),
+            ).rejects.toThrowError(FirestoreError)
+
+            // And the data should be not be updated;
+            const stored = await firestore
+                .collection("myCollection")
+                .doc("id1")
+                .get()
+            expect(stored.exists).toBe(true)
+            expect(stored.data()).toEqual({
+                field1: "value 1",
+                field2: "value 2",
+            })
+        })
+
+        test("throws with an undefined nested field", async () => {
+            // Given there is a doc;
+            firestore.resetStorage({
+                myCollection: {
+                    id1: { field1: "value 1", field2: "value 2" },
+                },
+            })
+
+            // When we update the doc with a different value, it throws;
+            await expect(
+                firestore
+                    .collection("myCollection")
+                    .doc("id1")
+                    .update({
+                        field2: "new value 2",
+                        foo: {
+                            bar: undefined,
+                        },
                         amount: 123,
                     }),
             ).rejects.toThrowError(FirestoreError)


### PR DESCRIPTION
## PR template

1. [x] Title has JIRA ticket number 
1. [x] Title has brief description
1. [x] Sections below are complete 
1. [ ] Documentation and sequence diagram/s have been included where appropriate

## Description

Undefined fields should are not allowed to be set on a firestore document. This change ensures that child values are not undefined when setting/updating document data.

## Outcome (why it changed. Please ensure that non-eng can understand the reasons behind this PR)

Dev tooling, no customer impact.