### PR TITLE
Fix query checking the value and type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -437,18 +437,12 @@ export class InProcessFirestoreQuery implements IFirestoreQuery {
                 break
             case "==":
                 filter = (idItem) => {
-                    return (
-                        String(objGet(idItem.item, fieldObjPath)) ===
-                        String(value)
-                    )
+                    return objGet(idItem.item, fieldObjPath) === value
                 }
                 break
             case "!=":
                 filter = (idItem) => {
-                    return (
-                        String(objGet(idItem.item, fieldObjPath)) !==
-                        String(value)
-                    )
+                    return objGet(idItem.item, fieldObjPath) !== value
                 }
                 break
             case ">=":

--- a/tests/driver/Firestore/InProcessFirestore.where.basic.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.where.basic.test.ts
@@ -641,4 +641,38 @@ describe("InProcessFirestore querying with where", () => {
             { name: "bear", eats: ["honey", "chips"] },
         ])
     })
+
+    test("where == 'true'", async () => {
+        // Given a collection of docs with differing values in a field;
+        firestore.resetStorage({
+            animals: {
+                tiger: {
+                    name: "tiger",
+                    cat: true,
+                },
+                hyena: {
+                    name: "hyena",
+                    cat: false,
+                },
+                lion: {
+                    name: "lion",
+                    cat: true,
+                },
+                bear: {
+                    name: "bear",
+                    cat: false,
+                },
+            },
+        })
+
+        // When we query docs by that field;
+        const result = await firestore
+            .collection("animals")
+            .where("cat", "==", "true")
+            .get()
+
+        // Then we should get the correct results.
+        expect(result.size).toBe(0)
+        expect(result.empty).toBeTruthy()
+    })
 })


### PR DESCRIPTION
Fixing issue: https://github.com/freetrade-io/ts-firebase-driver-testing/issues/122

Firestore differentiates by type when it queries, so `true !== 'true'`. Our current code is stringifying the values, so our query differs from the real firestore behaviour. This PR is fixing it