### PR TITLE
Simplify Firestore Change Observers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/AsyncJobs.ts
+++ b/src/driver/AsyncJobs.ts
@@ -3,7 +3,9 @@ import { sleep } from "../util/sleep"
 
 export interface IAsyncJobs {
     pushJob(job: Promise<any>): void
+
     pushJobs(jobs: Array<Promise<any>>): void
+
     jobsComplete(): Promise<void>
 }
 
@@ -12,7 +14,7 @@ export class AsyncJobs implements IAsyncJobs {
 
     // To prevent trying to resolve 100s or possibly 1000s of promises at once
     // maxConcurrentJobs was added
-    constructor(private maxConcurrentJobs: number = 20) {}
+    constructor(private maxConcurrentJobs: number) {}
 
     pushJobs(jobs: Array<Promise<any>>): void {
         this.jobs = this.jobs.concat(jobs.map((job) => randomDelayJob(job)))
@@ -51,7 +53,7 @@ export class AsyncJobs implements IAsyncJobs {
  */
 function randomDelayJob(job: Promise<any>): Promise<any> {
     return (async () => {
-        await sleep(Math.random() * 10)
+        await sleep(Math.random() * 5)
         await job
     })()
 }

--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -1,9 +1,9 @@
 import { flatten } from "flat"
 import _ from "lodash"
+import objectPath = require("object-path")
 import { enumeratePaths } from "../../util/enumeratePaths"
 import { JsonValue } from "../../util/json"
 import { makeDelta } from "../../util/makeDelta"
-import objectPath = require("object-path")
 
 /**
  * Firebase triggers get before/after, GCP cloud function triggers get
@@ -378,7 +378,7 @@ export class FirestoreDeletedChangeFilter extends ChangeFilter {
                 change: {
                     before: change.before,
                     after: undefined,
-                    data: change.after,
+                    data: change.before,
                     delta: undefined,
                 },
                 path: documentPath,

--- a/src/driver/ChangeObserver/DatabaseChangeFilter.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeFilter.ts
@@ -1,9 +1,9 @@
 import { flatten } from "flat"
 import _ from "lodash"
-import objectPath = require("object-path")
 import { enumeratePaths } from "../../util/enumeratePaths"
 import { JsonValue } from "../../util/json"
 import { makeDelta } from "../../util/makeDelta"
+import objectPath = require("object-path")
 
 /**
  * Firebase triggers get before/after, GCP cloud function triggers get
@@ -30,6 +30,7 @@ export interface IChangeParams {
 export interface IChangeFilter {
     readonly observedPath: string
     readonly observedPathRegex: RegExp
+
     changeEvents(change: IChange, dotPath?: string[]): IParameterisedChange[]
 }
 
@@ -47,6 +48,7 @@ abstract class ChangeFilter implements IChangeFilter {
         name: string
         index: number
     }>
+
     constructor(readonly observedPath: string) {
         this.observedPath = normalisePath(observedPath)
         const pathParts = this.observedPath.split("/")
@@ -134,6 +136,39 @@ abstract class ChangeFilter implements IChangeFilter {
             match: false,
             parameters: {},
         }
+    }
+}
+
+export class FirestoreCreatedChangeFilter extends ChangeFilter {
+    changeEvents(change: IChange, _dotPath?: string[]): IParameterisedChange[] {
+        const dotPath = _dotPath! // inProcessFirestore always provides dotPath
+        // Firestore doesn't use dotPath change observers, so don't bother looking up nested paths
+        const documentPath = dotPath.join("/")
+        const isPreexistingDocument = typeof change.before === "object"
+        const doesntExistAfter = typeof change.after !== "object"
+        if (isPreexistingDocument || doesntExistAfter) {
+            // This is not a newly created path.
+            return []
+        }
+
+        const matchPath = this.matchPath(documentPath)
+        if (!matchPath.match) {
+            // We're not interested in this path.
+            return []
+        }
+
+        return [
+            {
+                parameters: matchPath.parameters,
+                change: {
+                    before: undefined,
+                    after: change.after,
+                    data: undefined,
+                    delta: change.after,
+                },
+                path: documentPath,
+            },
+        ]
     }
 }
 
@@ -233,6 +268,44 @@ export class UpdatedChangeFilter extends ChangeFilter {
     }
 }
 
+export class FirestoreUpdatedChangeFilter extends ChangeFilter {
+    changeEvents(change: IChange, _dotPath?: string[]): IParameterisedChange[] {
+        const dotPath = _dotPath! // inProcessFirestore always provides dotPath
+        // Firestore doesn't use dotPath change observers, so don't bother looking up nested paths
+        const documentPath = dotPath.join("/")
+        const doesntExistBefore = typeof change.before !== "object"
+        const doesntExistAfter = typeof change.after !== "object"
+
+        if (doesntExistBefore || doesntExistAfter) {
+            // This is not an updated path, it's been created/deleted so ignore it
+            return []
+        }
+
+        const matchPath = this.matchPath(documentPath)
+        if (!matchPath.match) {
+            // We're not interested in this path.
+            return []
+        }
+
+        if (!_.isEqual(change.after, change.before)) {
+            return [
+                {
+                    parameters: matchPath.parameters,
+                    change: {
+                        before: change.before,
+                        after: change.after,
+                        data: change.before,
+                        delta: makeDelta(change.before!, change.after!),
+                    },
+                    path: documentPath,
+                },
+            ]
+        }
+
+        return []
+    }
+}
+
 export class DeletedChangeFilter extends ChangeFilter {
     changeEvents(change: IChange, dotPath?: string[]): IParameterisedChange[] {
         const paths = this.changePaths(change, dotPath)
@@ -281,6 +354,39 @@ export class DeletedChangeFilter extends ChangeFilter {
     }
 }
 
+export class FirestoreDeletedChangeFilter extends ChangeFilter {
+    changeEvents(change: IChange, _dotPath?: string[]): IParameterisedChange[] {
+        const dotPath = _dotPath! // inProcessFirestore always provides dotPath
+        // Firestore doesn't use dotPath change observers, so don't bother looking up nested paths
+        const documentPath = dotPath.join("/")
+        const doesntExistBefore = typeof change.before !== "object"
+        const existsAfter = typeof change.after === "object"
+        if (doesntExistBefore || existsAfter) {
+            // This is not a deleted path.
+            return []
+        }
+
+        const matchPath = this.matchPath(documentPath)
+        if (!matchPath.match) {
+            // We're not interested in this path.
+            return []
+        }
+
+        return [
+            {
+                parameters: matchPath.parameters,
+                change: {
+                    before: change.before,
+                    after: undefined,
+                    data: change.after,
+                    delta: undefined,
+                },
+                path: documentPath,
+            },
+        ]
+    }
+}
+
 export class WrittenChangeFilter extends ChangeFilter {
     changeEvents(change: IChange, dotPath?: string[]): IParameterisedChange[] {
         return [
@@ -293,6 +399,25 @@ export class WrittenChangeFilter extends ChangeFilter {
                 dotPath,
             ),
             ...new DeletedChangeFilter(this.observedPath).changeEvents(
+                change,
+                dotPath,
+            ),
+        ]
+    }
+}
+
+export class FirestoreWrittenChangeFilter extends ChangeFilter {
+    changeEvents(change: IChange, dotPath?: string[]): IParameterisedChange[] {
+        return [
+            ...new FirestoreCreatedChangeFilter(this.observedPath).changeEvents(
+                change,
+                dotPath,
+            ),
+            ...new FirestoreUpdatedChangeFilter(this.observedPath).changeEvents(
+                change,
+                dotPath,
+            ),
+            ...new FirestoreDeletedChangeFilter(this.observedPath).changeEvents(
                 change,
                 dotPath,
             ),

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -2,12 +2,12 @@ import _ from "lodash"
 import { JsonValue } from "../../util/json"
 import { stripMeta } from "../../util/stripMeta"
 import {
-    CreatedChangeFilter,
-    DeletedChangeFilter,
+    FirestoreCreatedChangeFilter,
+    FirestoreDeletedChangeFilter,
+    FirestoreUpdatedChangeFilter,
+    FirestoreWrittenChangeFilter,
     IChangeFilter,
     IParameterisedChange,
-    UpdatedChangeFilter,
-    WrittenChangeFilter,
 } from "../ChangeObserver/DatabaseChangeFilter"
 import {
     ChangeType,
@@ -15,16 +15,8 @@ import {
     IChangeSnapshots,
     TriggerFunction,
 } from "../ChangeObserver/DatabaseChangeObserver"
-import {
-    IFirestore,
-    IFirestoreDocRef,
-    IFirestoreDocumentData,
-    IFirestoreDocumentSnapshot,
-} from "./IFirestore"
-import {
-    InProcessFirestore,
-    InProcessFirestoreDocRef,
-} from "./InProcessFirestore"
+import { IFirestore, IFirestoreDocRef, IFirestoreDocumentData, IFirestoreDocumentSnapshot } from "./IFirestore"
+import { InProcessFirestore, InProcessFirestoreDocRef } from "./InProcessFirestore"
 import { InProcessFirestoreDocumentSnapshot } from "./InProcessFirestoreDocumentSnapshot"
 
 export function makeFirestoreChangeObserver(
@@ -59,6 +51,7 @@ export function makeFirestoreChangeObserver(
 
 export interface IFirestoreChangeSnapshot {
     exists: boolean
+
     data(): any
 }
 
@@ -87,7 +80,7 @@ class FirestoreCreatedObserver extends DatabaseChangeObserver<
     }
 
     protected changeFilter(): IChangeFilter {
-        return new CreatedChangeFilter(this.observedPath)
+        return new FirestoreCreatedChangeFilter(this.observedPath)
     }
 
     protected makeChangeObject(
@@ -108,7 +101,7 @@ class FirestoreUpdatedObserver extends DatabaseChangeObserver<
     IFirestoreChangeSnapshot
 > {
     protected changeFilter(): IChangeFilter {
-        return new UpdatedChangeFilter(this.observedPath)
+        return new FirestoreUpdatedChangeFilter(this.observedPath)
     }
 
     protected makeChangeObject(
@@ -141,7 +134,7 @@ class FirestoreDeletedObserver extends DatabaseChangeObserver<
     }
 
     protected changeFilter(): IChangeFilter {
-        return new DeletedChangeFilter(this.observedPath)
+        return new FirestoreDeletedChangeFilter(this.observedPath)
     }
 
     protected makeChangeObject(
@@ -170,7 +163,7 @@ class FirestoreWrittenObserver extends DatabaseChangeObserver<
     }
 
     protected changeFilter(): IChangeFilter {
-        return new WrittenChangeFilter(this.observedPath)
+        return new FirestoreWrittenChangeFilter(this.observedPath)
     }
 
     protected makeChangeObject(

--- a/src/driver/Firestore/FirestoreChangeObserver.ts
+++ b/src/driver/Firestore/FirestoreChangeObserver.ts
@@ -15,8 +15,16 @@ import {
     IChangeSnapshots,
     TriggerFunction,
 } from "../ChangeObserver/DatabaseChangeObserver"
-import { IFirestore, IFirestoreDocRef, IFirestoreDocumentData, IFirestoreDocumentSnapshot } from "./IFirestore"
-import { InProcessFirestore, InProcessFirestoreDocRef } from "./InProcessFirestore"
+import {
+    IFirestore,
+    IFirestoreDocRef,
+    IFirestoreDocumentData,
+    IFirestoreDocumentSnapshot,
+} from "./IFirestore"
+import {
+    InProcessFirestore,
+    InProcessFirestoreDocRef,
+} from "./InProcessFirestore"
 import { InProcessFirestoreDocumentSnapshot } from "./InProcessFirestoreDocumentSnapshot"
 
 export function makeFirestoreChangeObserver(

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -207,18 +207,8 @@ export class InProcessFirestore implements IFirestore {
         const data = before
         const delta = makeDelta(before, after)
 
-        const jobs = this.changeObservers.map(
-            async (observer) =>
-                new Promise((resolve) => {
-                    setTimeout(async () => {
-                        resolve(
-                            observer.onChange(
-                                { before, after, data, delta },
-                                dotPath,
-                            ),
-                        )
-                    }, 1)
-                }),
+        const jobs = this.changeObservers.map(async (observer) =>
+            observer.onChange({ before, after, data, delta }, dotPath),
         )
 
         this.jobs.pushJobs(jobs)
@@ -302,6 +292,7 @@ export class InProcessFirestoreQuery implements IFirestoreQuery {
         }
         query.rangeFilterField = fieldPath
     }
+
     constructor(
         readonly firestore: IFirestore & InProcessFirestore,
         readonly path: string,

--- a/src/driver/InProcessFirebaseDriver.ts
+++ b/src/driver/InProcessFirebaseDriver.ts
@@ -45,8 +45,8 @@ export class InProcessFirebaseDriver implements IFirebaseDriver, IAsyncJobs {
     private functionBuilder: InProcessFirebaseFunctionBuilder | undefined
     private firebaseAuth: InProcessFirebaseAuth | undefined
 
-    constructor() {
-        this.asyncJobs = new AsyncJobs()
+    constructor(maxConcurrentAsyncJobs: number = 20) {
+        this.asyncJobs = new AsyncJobs(maxConcurrentAsyncJobs)
     }
 
     realTimeDatabase(

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onDelete.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onDelete.test.ts
@@ -1,0 +1,103 @@
+import { IFirebaseDriver, IFirestoreDocumentSnapshot, InProcessFirebaseDriver } from "../../../../src"
+
+describe("onDelete trigger of in-process Firestore", () => {
+    let driver: InProcessFirebaseDriver & IFirebaseDriver
+
+    beforeEach(() => {
+        driver = new InProcessFirebaseDriver()
+    })
+
+    test("onDelete handler is not triggered on doc create", async () => {
+        // Given we set up an onDelete handler on a collection;
+        const receivedSnapshots: IFirestoreDocumentSnapshot[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onDelete(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({
+                colour: "orange", size: "large",
+            })
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should not be triggered.
+        expect(receivedSnapshots).toHaveLength(0)
+    })
+
+    test("onDelete handler is triggered on doc delete", async () => {
+        // Given we set up an onDelete handler on a collection;
+        const receivedSnapshots: IFirestoreDocumentSnapshot[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onDelete(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And then deleted
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .delete()
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should be triggered.
+        expect(receivedSnapshots).toHaveLength(1)
+        expect(receivedSnapshots[0].exists).toBeFalsy()
+    })
+
+    test("onDelete handler is not triggered when a doc is updated", async () => {
+        // Given we set up an onDelete handler on a collection;
+        const receivedSnapshots: IFirestoreDocumentSnapshot[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onDelete(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And then updated
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .update({ colour: "red" })
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should not be triggered.
+        expect(receivedSnapshots).toHaveLength(0)
+    })
+
+
+})

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onDelete.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onDelete.test.ts
@@ -1,4 +1,8 @@
-import { IFirebaseDriver, IFirestoreDocumentSnapshot, InProcessFirebaseDriver } from "../../../../src"
+import {
+    IFirebaseDriver,
+    IFirestoreDocumentSnapshot,
+    InProcessFirebaseDriver,
+} from "../../../../src"
 
 describe("onDelete trigger of in-process Firestore", () => {
     let driver: InProcessFirebaseDriver & IFirebaseDriver
@@ -24,7 +28,8 @@ describe("onDelete trigger of in-process Firestore", () => {
             .collection("animals")
             .doc("tiger")
             .set({
-                colour: "orange", size: "large",
+                colour: "orange",
+                size: "large",
             })
 
         // And Firebase finishes its jobs;
@@ -98,6 +103,4 @@ describe("onDelete trigger of in-process Firestore", () => {
         // Then the handler should not be triggered.
         expect(receivedSnapshots).toHaveLength(0)
     })
-
-
 })

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onUpdate.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onUpdate.test.ts
@@ -1,4 +1,9 @@
-import { IFirebaseChange, IFirebaseDriver, IFirestoreDocumentSnapshot, InProcessFirebaseDriver } from "../../../../src"
+import {
+    IFirebaseChange,
+    IFirebaseDriver,
+    IFirestoreDocumentSnapshot,
+    InProcessFirebaseDriver,
+} from "../../../../src"
 
 describe("onUpdate trigger of in-process Firestore", () => {
     let driver: InProcessFirebaseDriver & IFirebaseDriver
@@ -9,7 +14,9 @@ describe("onUpdate trigger of in-process Firestore", () => {
 
     test("onUpdate handler is not triggered on doc create", async () => {
         // Given we set up an onUpdate handler on a collection;
-        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        const receivedSnapshots: Array<IFirebaseChange<
+            IFirestoreDocumentSnapshot
+        >> = []
         driver
             .runWith()
             .region("europe-west1")
@@ -34,7 +41,9 @@ describe("onUpdate trigger of in-process Firestore", () => {
 
     test("onUpdate handler is not triggered on doc delete", async () => {
         // Given we set up an onUpdate handler on a collection;
-        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        const receivedSnapshots: Array<IFirebaseChange<
+            IFirestoreDocumentSnapshot
+        >> = []
         driver
             .runWith()
             .region("europe-west1")
@@ -66,7 +75,9 @@ describe("onUpdate trigger of in-process Firestore", () => {
 
     test("onUpdate handler is triggered when a doc is updated", async () => {
         // Given we set up an onUpdate handler on a collection;
-        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        const receivedSnapshots: Array<IFirebaseChange<
+            IFirestoreDocumentSnapshot
+        >> = []
         driver
             .runWith()
             .region("europe-west1")
@@ -94,8 +105,9 @@ describe("onUpdate trigger of in-process Firestore", () => {
 
         // Then the handler should be triggered.
         expect(receivedSnapshots).toHaveLength(1)
-        expect(receivedSnapshots[0].after!.data()).toEqual({ colour: "red", size: "large" })
+        expect(receivedSnapshots[0].after!.data()).toEqual({
+            colour: "red",
+            size: "large",
+        })
     })
-
-
 })

--- a/tests/driver/Firestore/Trigger/InProcessFirestore.onUpdate.test.ts
+++ b/tests/driver/Firestore/Trigger/InProcessFirestore.onUpdate.test.ts
@@ -1,0 +1,101 @@
+import { IFirebaseChange, IFirebaseDriver, IFirestoreDocumentSnapshot, InProcessFirebaseDriver } from "../../../../src"
+
+describe("onUpdate trigger of in-process Firestore", () => {
+    let driver: InProcessFirebaseDriver & IFirebaseDriver
+
+    beforeEach(() => {
+        driver = new InProcessFirebaseDriver()
+    })
+
+    test("onUpdate handler is not triggered on doc create", async () => {
+        // Given we set up an onUpdate handler on a collection;
+        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onUpdate(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should not be triggered.
+        expect(receivedSnapshots).toHaveLength(0)
+    })
+
+    test("onUpdate handler is not triggered on doc delete", async () => {
+        // Given we set up an onUpdate handler on a collection;
+        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onUpdate(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And then deleted
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .delete()
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should not be triggered.
+        expect(receivedSnapshots).toHaveLength(0)
+    })
+
+    test("onUpdate handler is triggered when a doc is updated", async () => {
+        // Given we set up an onUpdate handler on a collection;
+        const receivedSnapshots: IFirebaseChange<IFirestoreDocumentSnapshot>[] = []
+        driver
+            .runWith()
+            .region("europe-west1")
+            .firestore.document("/animals/{animalName}")
+            .onUpdate(async (snapshot, context) => {
+                receivedSnapshots.push(snapshot)
+            })
+
+        // When a doc is created in that collection;
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .set({ colour: "orange", size: "large" })
+
+        // And then updated
+        await driver
+            .firestore()
+            .collection("animals")
+            .doc("tiger")
+            .update({ colour: "red" })
+
+        // And Firebase finishes its jobs;
+        await driver.jobsComplete()
+
+        // Then the handler should be triggered.
+        expect(receivedSnapshots).toHaveLength(1)
+        expect(receivedSnapshots[0].after!.data()).toEqual({ colour: "red", size: "large" })
+    })
+
+
+})

--- a/tests/driver/PubSub/InProcessFirebasePubSubTopic.publish.test.ts
+++ b/tests/driver/PubSub/InProcessFirebasePubSubTopic.publish.test.ts
@@ -9,7 +9,7 @@ describe("InProcessFirebasePubSubTopic publisher.publish", () => {
     test("Publishes a message to a topic with attributes and context.", async () => {
         // Given the mocks
         const topic = "Test-Topic"
-        const asyncJobs = new AsyncJobs()
+        const asyncJobs = new AsyncJobs(20)
         const dateMock = jest.fn()
 
         // Given the time is


### PR DESCRIPTION
Currently we make use the same change observers for both Firestore and RTDB. However, Firestore only supports observing documents, not subpaths within documents. This means we unnecessarily traverse every key within each document written to Firestore, when instead we can just do simple checks like 'did this document exist before'.

This PR adds Firestore specific change observers that do these much simpler checks and should avoid extraneous work traversing each document.