### PR TITLE
Add debug logs for identifying slow jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-firebase-driver-testing",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/AsyncJobs.ts
+++ b/src/driver/AsyncJobs.ts
@@ -3,15 +3,14 @@ import { sleep } from "../util/sleep"
 import { IDatabaseChangePerformanceStats } from "./ChangeObserver/DatabaseChangeObserver"
 
 export interface IAsyncJobs {
+    shouldDebugJobsCompletePerformance: boolean
     pushJob(job: Promise<any>): void
     pushJobs(jobs: Array<Promise<any>>): void
     jobsComplete(): Promise<void>
-
-    shouldDebugJobsCompletePerformance: boolean
 }
 
 export class AsyncJobs implements IAsyncJobs {
-    public shouldDebugJobsCompletePerformance = false
+    shouldDebugJobsCompletePerformance = false
     private jobs: Array<Promise<IDatabaseChangePerformanceStats>> = []
 
     // To prevent trying to resolve 100s or possibly 1000s of promises at once
@@ -44,23 +43,39 @@ export class AsyncJobs implements IAsyncJobs {
         this.logChangePerformanceStats(changePerformanceStats)
     }
 
-    private logChangePerformanceStats(stats: IDatabaseChangePerformanceStats[]) {
+    private logChangePerformanceStats(
+        stats: IDatabaseChangePerformanceStats[],
+    ) {
         if (!this.shouldDebugJobsCompletePerformance) {
             return
         }
 
         const maxSlowToShow = 20
         const slowest = _.orderBy(stats, "durationMillis", ["desc"])
-        const pathsWithoutIds = stats.map(stat => {
+        const pathsWithoutIds = stats.map((stat) => {
             const name = stat.path ?? stat.topicName ?? ""
             const components = name.split("/")
-            return components.map((val, i) => i % 2 === 0 ? val : "*").join("/")
+            return components
+                .map((val, i) => (i % 2 === 0 ? val : "*"))
+                .join("/")
         })
         const uniqueCollections = new Set(pathsWithoutIds)
-        console.log(`jobsComplete stats: there were ${stats.length} paths updated`)
-        console.log(`jobsComplete stats: there were ${uniqueCollections.size} collections updated`)
-        console.log(`jobsComplete stats: the collections that were updated were: ${JSON.stringify(Array.from(uniqueCollections), null, 2)}`)
-        console.log(`jobsComplete stats: the ${maxSlowToShow} slowest paths to process were:`)
+        console.log(
+            `jobsComplete stats: there were ${stats.length} paths updated`,
+        )
+        console.log(
+            `jobsComplete stats: there were ${uniqueCollections.size} collections updated`,
+        )
+        console.log(
+            `jobsComplete stats: the collections that were updated were: ${JSON.stringify(
+                Array.from(uniqueCollections),
+                null,
+                2,
+            )}`,
+        )
+        console.log(
+            `jobsComplete stats: the ${maxSlowToShow} slowest paths to process were:`,
+        )
         console.table(slowest.slice(0, maxSlowToShow))
     }
 

--- a/src/driver/AsyncJobs.ts
+++ b/src/driver/AsyncJobs.ts
@@ -1,39 +1,67 @@
 import _ from "lodash"
 import { sleep } from "../util/sleep"
+import { IDatabaseChangePerformanceStats } from "./ChangeObserver/DatabaseChangeObserver"
 
 export interface IAsyncJobs {
     pushJob(job: Promise<any>): void
     pushJobs(jobs: Array<Promise<any>>): void
     jobsComplete(): Promise<void>
+
+    shouldDebugJobsCompletePerformance: boolean
 }
 
 export class AsyncJobs implements IAsyncJobs {
-    private jobs: Array<Promise<any>> = []
+    public shouldDebugJobsCompletePerformance = false
+    private jobs: Array<Promise<IDatabaseChangePerformanceStats>> = []
 
     // To prevent trying to resolve 100s or possibly 1000s of promises at once
     // maxConcurrentJobs was added
     constructor(private maxConcurrentJobs: number = 20) {}
 
-    pushJobs(jobs: Array<Promise<any>>): void {
+    pushJobs(jobs: Array<Promise<IDatabaseChangePerformanceStats>>): void {
         this.jobs = this.jobs.concat(jobs.map((job) => randomDelayJob(job)))
     }
 
-    pushJob(job: Promise<any>): void {
+    pushJob(job: Promise<IDatabaseChangePerformanceStats>): void {
         this.jobs.push(randomDelayJob(job))
     }
 
     async jobsComplete(): Promise<void> {
         // More jobs might be added by each job, so we can't just await Promise.all() here
+        const changePerformanceStats: IDatabaseChangePerformanceStats[] = []
         while (this.jobs.length > 0) {
             this.randomiseJobsOrder()
 
             const itemsToResolve = this.jobs.slice(0, this.maxConcurrentJobs)
 
-            await Promise.all(itemsToResolve)
+            const results = await Promise.all(itemsToResolve)
+            changePerformanceStats.push(...results)
 
             // Remove the items we just processed from the front of the job queue
             this.jobs.splice(0, itemsToResolve.length)
         }
+
+        this.logChangePerformanceStats(changePerformanceStats)
+    }
+
+    private logChangePerformanceStats(stats: IDatabaseChangePerformanceStats[]) {
+        if (!this.shouldDebugJobsCompletePerformance) {
+            return
+        }
+
+        const maxSlowToShow = 20
+        const slowest = _.orderBy(stats, "durationMillis", ["desc"])
+        const pathsWithoutIds = stats.map(stat => {
+            const name = stat.path ?? stat.topicName ?? ""
+            const components = name.split("/")
+            return components.map((val, i) => i % 2 === 0 ? val : "*").join("/")
+        })
+        const uniqueCollections = new Set(pathsWithoutIds)
+        console.log(`jobsComplete stats: there were ${stats.length} paths updated`)
+        console.log(`jobsComplete stats: there were ${uniqueCollections.size} collections updated, the ones that were updated were:`)
+        console.log(`jobsComplete stats: the collections that were updated were: ${JSON.stringify(Array.from(uniqueCollections), null, 2)}`)
+        console.log(`jobsComplete stats: the ${maxSlowToShow} slowest paths to process were:`)
+        console.table(slowest.slice(0, maxSlowToShow))
     }
 
     /**
@@ -52,6 +80,6 @@ export class AsyncJobs implements IAsyncJobs {
 function randomDelayJob(job: Promise<any>): Promise<any> {
     return (async () => {
         await sleep(Math.random() * 10)
-        await job
+        return job
     })()
 }

--- a/src/driver/AsyncJobs.ts
+++ b/src/driver/AsyncJobs.ts
@@ -58,7 +58,7 @@ export class AsyncJobs implements IAsyncJobs {
         })
         const uniqueCollections = new Set(pathsWithoutIds)
         console.log(`jobsComplete stats: there were ${stats.length} paths updated`)
-        console.log(`jobsComplete stats: there were ${uniqueCollections.size} collections updated, the ones that were updated were:`)
+        console.log(`jobsComplete stats: there were ${uniqueCollections.size} collections updated`)
         console.log(`jobsComplete stats: the collections that were updated were: ${JSON.stringify(Array.from(uniqueCollections), null, 2)}`)
         console.log(`jobsComplete stats: the ${maxSlowToShow} slowest paths to process were:`)
         console.table(slowest.slice(0, maxSlowToShow))

--- a/src/driver/ChangeObserver/DatabaseChangeObserver.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeObserver.ts
@@ -14,7 +14,10 @@ export interface IDatabaseChangePerformanceStats {
 }
 
 export interface IDatabaseChangeObserver {
-    onChange(change: IChange, dotPath?: string[]): Promise<IDatabaseChangePerformanceStats>
+    onChange(
+        change: IChange,
+        dotPath?: string[],
+    ): Promise<IDatabaseChangePerformanceStats>
 }
 
 export type ChangeType = "created" | "updated" | "deleted" | "written"
@@ -41,10 +44,12 @@ export abstract class DatabaseChangeObserver<T>
     constructor(
         protected readonly observedPath: string,
         protected readonly handler: TriggerFunction<T>,
-    ) {
-    }
+    ) {}
 
-    async onChange(change: IChange, dotPath?: string[]): Promise<IDatabaseChangePerformanceStats> {
+    async onChange(
+        change: IChange,
+        dotPath?: string[],
+    ): Promise<IDatabaseChangePerformanceStats> {
         const start = performance.now()
         const relevantChanges = this.changeFilter().changeEvents(
             change,

--- a/src/driver/ChangeObserver/DatabaseChangeObserver.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeObserver.ts
@@ -1,3 +1,4 @@
+import { performance } from "perf_hooks"
 import { JsonValue } from "../../util/json"
 import {
     IChange,
@@ -6,8 +7,14 @@ import {
     IParameterisedChange,
 } from "./DatabaseChangeFilter"
 
+export interface IDatabaseChangePerformanceStats {
+    path?: string
+    topicName?: string
+    durationMillis: number
+}
+
 export interface IDatabaseChangeObserver {
-    onChange(change: IChange, dotPath?: string[]): Promise<void>
+    onChange(change: IChange, dotPath?: string[]): Promise<IDatabaseChangePerformanceStats>
 }
 
 export type ChangeType = "created" | "updated" | "deleted" | "written"
@@ -34,21 +41,32 @@ export abstract class DatabaseChangeObserver<T>
     constructor(
         protected readonly observedPath: string,
         protected readonly handler: TriggerFunction<T>,
-    ) {}
+    ) {
+    }
 
-    async onChange(change: IChange, dotPath?: string[]): Promise<void> {
+    async onChange(change: IChange, dotPath?: string[]): Promise<IDatabaseChangePerformanceStats> {
+        const start = performance.now()
         const relevantChanges = this.changeFilter().changeEvents(
             change,
             dotPath,
         )
         await Promise.all(
             relevantChanges.map((pc: IParameterisedChange) => {
-                return this.handler(this.makeChangeObject(pc), {
-                    params: pc.parameters,
-                    timestamp: new Date().toISOString(),
+                return new Promise((resolve, reject) => {
+                    this.handler(this.makeChangeObject(pc), {
+                        params: pc.parameters,
+                        timestamp: new Date().toISOString(),
+                    }).then(resolve, reject)
                 })
             }),
         )
+
+        const path = (dotPath || []).join("/")
+        const duration = performance.now() - start
+        return {
+            path,
+            durationMillis: Math.abs(duration),
+        }
     }
 
     protected abstract changeFilter(): IChangeFilter

--- a/src/driver/InProcessFirebaseDriver.ts
+++ b/src/driver/InProcessFirebaseDriver.ts
@@ -25,8 +25,7 @@ class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
         readonly pubsub: InProcessFirebaseBuilderPubSub,
         readonly database: InProcessFirebaseBuilderDatabase,
         readonly firestore: InProcessFirestoreBuilder,
-    ) {
-    }
+    ) {}
 
     region(
         ...regions: Array<typeof SUPPORTED_REGIONS[number]>
@@ -36,7 +35,7 @@ class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
 }
 
 export class InProcessFirebaseDriver implements IFirebaseDriver, IAsyncJobs {
-    public shouldDebugJobsCompletePerformance: boolean = false
+    shouldDebugJobsCompletePerformance: boolean = false
     private rtDb: InProcessRealtimeDatabase | undefined
     private firestoreDb: InProcessFirestore | undefined
     private asyncJobs: IAsyncJobs

--- a/src/driver/InProcessFirebaseDriver.ts
+++ b/src/driver/InProcessFirebaseDriver.ts
@@ -25,7 +25,8 @@ class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
         readonly pubsub: InProcessFirebaseBuilderPubSub,
         readonly database: InProcessFirebaseBuilderDatabase,
         readonly firestore: InProcessFirestoreBuilder,
-    ) {}
+    ) {
+    }
 
     region(
         ...regions: Array<typeof SUPPORTED_REGIONS[number]>
@@ -35,6 +36,7 @@ class InProcessFirebaseFunctionBuilder implements IFirebaseFunctionBuilder {
 }
 
 export class InProcessFirebaseDriver implements IFirebaseDriver, IAsyncJobs {
+    public shouldDebugJobsCompletePerformance: boolean = false
     private rtDb: InProcessRealtimeDatabase | undefined
     private firestoreDb: InProcessFirestore | undefined
     private asyncJobs: IAsyncJobs
@@ -129,5 +131,9 @@ export class InProcessFirebaseDriver implements IFirebaseDriver, IAsyncJobs {
 
     async jobsComplete(): Promise<void> {
         await this.asyncJobs.jobsComplete()
+    }
+
+    setDebugJobsCompletePerformanceEnabled(debugEnabled: boolean) {
+        this.asyncJobs.shouldDebugJobsCompletePerformance = debugEnabled
     }
 }

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -95,7 +95,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
                         timestamp: this.now().toISOString(),
                     }).then(() => resolve({
                         topicName: topicName,
-                        durationMillis: Math.abs(performance.now() - start),
+                        durationMillis: start - performance.now(),
                     }))
                 },
             )

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -36,8 +36,7 @@ export class InProcessFirebaseTopicBuilder implements IFirebaseTopicBuilder {
     constructor(
         readonly name: string,
         private readonly pubSub: InProcessFirebaseBuilderPubSub,
-    ) {
-    }
+    ) {}
 
     onPublish(
         handler: (
@@ -65,8 +64,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
     constructor(
         private readonly jobs: IAsyncJobs,
         private readonly now: () => Date = () => new Date(),
-    ) {
-    }
+    ) {}
 
     schedule(schedule: string): InProcessFirebaseScheduleBuilder {
         return new InProcessFirebaseScheduleBuilder()
@@ -89,14 +87,17 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
         }
         for (const handler of this.subscriptions[topicName]) {
             const start = performance.now()
-            const job = new Promise<IDatabaseChangePerformanceStats>((resolve) => {
+            const job = new Promise<IDatabaseChangePerformanceStats>(
+                (resolve) => {
                     const message = new PubSubMessage(data, attributes ?? {})
                     handler(message, {
                         timestamp: this.now().toISOString(),
-                    }).then(() => resolve({
-                        topicName: topicName,
-                        durationMillis: start - performance.now(),
-                    }))
+                    }).then(() =>
+                        resolve({
+                            topicName,
+                            durationMillis: start - performance.now(),
+                        }),
+                    )
                 },
             )
             this.jobs.pushJob(job)
@@ -105,8 +106,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
 }
 
 class InProcessPubSubPublisher implements IPubSubPublisher {
-    constructor(private readonly topic: InProcessFirebasePubSubTopic) {
-    }
+    constructor(private readonly topic: InProcessFirebasePubSubTopic) {}
 
     // @ts-ignore
     publish(data: Buffer, attributes?: Attributes): Promise<void> {
@@ -134,8 +134,7 @@ export class InProcessFirebasePubSubCl implements IPubSub {
         [key: string]: InProcessFirebasePubSubTopic
     } = {}
 
-    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {
-    }
+    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {}
 
     topic(name: string): InProcessFirebasePubSubTopic {
         if (!this.topics[name]) {

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -360,7 +360,7 @@ export class InProcessRealtimeDatabaseRef
         eventType: "value",
     ): Promise<InProcessFirebaseRealtimeDatabaseSnapshot> {
         if (eventType !== "value") {
-            throw new Error("Only the \"value\" event type is supported.")
+            throw new Error('Only the "value" event type is supported.')
         }
         let value = this.db._getPath(this.path)
         if (typeof value === "object") {
@@ -546,7 +546,7 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
             const job = new Promise<IDatabaseChangePerformanceStats>((resolve) => {
                 observer.onChange({ before, after, data, delta }).then(() => resolve({
                     path,
-                    durationMillis: Math.abs(performance.now() - start),
+                    durationMillis: start - performance.now(),
                 }))
             })
             this.jobs.pushJob(job)

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -32,8 +32,7 @@ export class InProcessFirebaseRealtimeDatabaseSnapshot
         readonly key: string,
         readonly ref: InProcessRealtimeDatabaseRef,
         private readonly value: any,
-    ) {
-    }
+    ) {}
 
     exists(): boolean {
         if (this.value && typeof this.value === "object") {
@@ -127,8 +126,7 @@ export class InProcessRealtimeDatabaseRef
             keyOrdering: false,
             childOrderingPath: undefined,
         },
-    ) {
-    }
+    ) {}
 
     orderByKey(): InProcessRealtimeDatabaseRef {
         const ordering = (a: IKeyVal, b: IKeyVal): number => {
@@ -453,8 +451,7 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
     constructor(
         private readonly jobs?: IAsyncJobs,
         private readonly idGenerator: IdGenerator = firebaseLikeId,
-    ) {
-    }
+    ) {}
 
     ref(path: string): InProcessRealtimeDatabaseRef {
         return new InProcessRealtimeDatabaseRef(
@@ -543,12 +540,16 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
 
         for (const observer of this.changeObservers) {
             const start = performance.now()
-            const job = new Promise<IDatabaseChangePerformanceStats>((resolve) => {
-                observer.onChange({ before, after, data, delta }).then(() => resolve({
-                    path,
-                    durationMillis: start - performance.now(),
-                }))
-            })
+            const job = new Promise<IDatabaseChangePerformanceStats>(
+                (resolve) => {
+                    observer.onChange({ before, after, data, delta }).then(() =>
+                        resolve({
+                            path,
+                            durationMillis: start - performance.now(),
+                        }),
+                    )
+                },
+            )
             this.jobs.pushJob(job)
         }
     }
@@ -558,8 +559,7 @@ export class InProcessFirebaseRefBuilder implements IFirebaseRefBuilder {
     constructor(
         readonly path: string,
         private readonly database: InProcessRealtimeDatabase,
-    ) {
-    }
+    ) {}
 
     onCreate(
         handler: (
@@ -620,8 +620,7 @@ export class InProcessFirebaseRefBuilder implements IFirebaseRefBuilder {
 
 export class InProcessFirebaseBuilderDatabase
     implements IFirebaseBuilderDatabase {
-    constructor(private readonly database: InProcessRealtimeDatabase) {
-    }
+    constructor(private readonly database: InProcessRealtimeDatabase) {}
 
     ref(path: string): InProcessFirebaseRefBuilder {
         return new InProcessFirebaseRefBuilder(path, this.database)

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
     "max-classes-per-file": [false, 1],
     "object-literal-sort-keys": [false],
     "no-empty": [true, "allow-empty-functions"],
+    "no-console": false,
     "variable-name": {
       "options": [
         "allow-leading-underscore"


### PR DESCRIPTION
When testing lots of asynchronous code, `jobsComplete()` can become slow and it's often hard to find the source of the slowdown. This adds an opt in log that prints out a) the documents that database triggers ran on, b) the collections that had the most triggers, and c) the 20 slowest database triggers to run in milliseconds.

![image](https://user-images.githubusercontent.com/57354269/148544425-b4a3d00b-e5b3-4c04-a8ab-f4175d4d8688.png)
