### PR TITLE
Fix performance logging showing negative numbers

### DIFF
--- a/src/driver/ChangeObserver/DatabaseChangeObserver.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeObserver.ts
@@ -44,8 +44,7 @@ export abstract class DatabaseChangeObserver<T>
     constructor(
         protected readonly observedPath: string,
         protected readonly handler: TriggerFunction<T>,
-    ) {
-    }
+    ) {}
 
     async onChange(
         change: IChange,

--- a/src/driver/ChangeObserver/DatabaseChangeObserver.ts
+++ b/src/driver/ChangeObserver/DatabaseChangeObserver.ts
@@ -44,7 +44,8 @@ export abstract class DatabaseChangeObserver<T>
     constructor(
         protected readonly observedPath: string,
         protected readonly handler: TriggerFunction<T>,
-    ) {}
+    ) {
+    }
 
     async onChange(
         change: IChange,
@@ -70,7 +71,7 @@ export abstract class DatabaseChangeObserver<T>
         const duration = performance.now() - start
         return {
             path,
-            durationMillis: Math.abs(duration),
+            durationMillis: duration,
         }
     }
 

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -36,7 +36,8 @@ export class InProcessFirebaseTopicBuilder implements IFirebaseTopicBuilder {
     constructor(
         readonly name: string,
         private readonly pubSub: InProcessFirebaseBuilderPubSub,
-    ) {}
+    ) {
+    }
 
     onPublish(
         handler: (
@@ -64,7 +65,8 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
     constructor(
         private readonly jobs: IAsyncJobs,
         private readonly now: () => Date = () => new Date(),
-    ) {}
+    ) {
+    }
 
     schedule(schedule: string): InProcessFirebaseScheduleBuilder {
         return new InProcessFirebaseScheduleBuilder()
@@ -95,7 +97,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
                     }).then(() =>
                         resolve({
                             topicName,
-                            durationMillis: start - performance.now(),
+                            durationMillis: performance.now() - start,
                         }),
                     )
                 },
@@ -106,7 +108,8 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
 }
 
 class InProcessPubSubPublisher implements IPubSubPublisher {
-    constructor(private readonly topic: InProcessFirebasePubSubTopic) {}
+    constructor(private readonly topic: InProcessFirebasePubSubTopic) {
+    }
 
     // @ts-ignore
     publish(data: Buffer, attributes?: Attributes): Promise<void> {
@@ -134,7 +137,8 @@ export class InProcessFirebasePubSubCl implements IPubSub {
         [key: string]: InProcessFirebasePubSubTopic
     } = {}
 
-    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {}
+    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {
+    }
 
     topic(name: string): InProcessFirebasePubSubTopic {
         if (!this.topics[name]) {

--- a/src/driver/PubSub/InProcessFirebasePubSub.ts
+++ b/src/driver/PubSub/InProcessFirebasePubSub.ts
@@ -36,8 +36,7 @@ export class InProcessFirebaseTopicBuilder implements IFirebaseTopicBuilder {
     constructor(
         readonly name: string,
         private readonly pubSub: InProcessFirebaseBuilderPubSub,
-    ) {
-    }
+    ) {}
 
     onPublish(
         handler: (
@@ -65,8 +64,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
     constructor(
         private readonly jobs: IAsyncJobs,
         private readonly now: () => Date = () => new Date(),
-    ) {
-    }
+    ) {}
 
     schedule(schedule: string): InProcessFirebaseScheduleBuilder {
         return new InProcessFirebaseScheduleBuilder()
@@ -108,8 +106,7 @@ export class InProcessFirebaseBuilderPubSub implements IFirebaseBuilderPubSub {
 }
 
 class InProcessPubSubPublisher implements IPubSubPublisher {
-    constructor(private readonly topic: InProcessFirebasePubSubTopic) {
-    }
+    constructor(private readonly topic: InProcessFirebasePubSubTopic) {}
 
     // @ts-ignore
     publish(data: Buffer, attributes?: Attributes): Promise<void> {
@@ -137,8 +134,7 @@ export class InProcessFirebasePubSubCl implements IPubSub {
         [key: string]: InProcessFirebasePubSubTopic
     } = {}
 
-    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {
-    }
+    constructor(private readonly pubSub: InProcessFirebaseBuilderPubSub) {}
 
     topic(name: string): InProcessFirebasePubSubTopic {
         if (!this.topics[name]) {

--- a/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
+++ b/src/driver/RealtimeDatabase/InProcessRealtimeDatabase.ts
@@ -545,7 +545,7 @@ export class InProcessRealtimeDatabase implements IFirebaseRealtimeDatabase {
                     observer.onChange({ before, after, data, delta }).then(() =>
                         resolve({
                             path,
-                            durationMillis: start - performance.now(),
+                            durationMillis: performance.now() - start,
                         }),
                     )
                 },


### PR DESCRIPTION
I removed `Math.abs()` usages when going through review feedback and merged some broken code just as Luke pointed out it was still broken. 

I've verified this works now: 
![image](https://user-images.githubusercontent.com/57354269/148560574-e03c0178-46b3-461c-a89e-0933fdcc224a.png)

I looked at adding tests for the values being positive, but we'd have to expose the jobs somehow, which I'm not sure is worth it for debug logging.