### PR TITLE
Feature - Support deletes in firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "p-limit": "^3.1.0"
   },
   "devDependencies": {
+    "@google-cloud/firestore": "^5.0.2",
     "@types/flat": "^5.0.0",
     "@types/jest": "^25.1.0",
     "@types/lodash": "^4",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1,3 +1,4 @@
+import { FieldValue } from "@google-cloud/firestore"
 import flatten from "flat"
 import _ from "lodash"
 import { Readable } from "stream"
@@ -973,6 +974,16 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         )
         for (const [path, newValue] of Object.entries(updateDelta)) {
             const pathComponents = path.includes(".") ? path.split(".") : [path]
+
+            // Handling deleteTransform. The class type is not exported from the lib, so we need to decode it
+            if (
+                newValue.constructor.name === "DeleteTransform" &&
+                newValue.methodName === "FieldValue.delete"
+            ) {
+                objDel(valueToWrite, pathComponents)
+                continue
+            }
+
             const existingValue = objGet(valueToWrite, pathComponents)
             const mergedValue =
                 mergeWithExisting &&

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -977,8 +977,8 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
 
             // Handling deleteTransform. The class type is not exported from the lib, so we need to decode it
             if (
-                newValue.constructor.name === "DeleteTransform" &&
-                newValue.methodName === "FieldValue.delete"
+                newValue?.constructor?.name === "DeleteTransform" &&
+                newValue?.methodName === "FieldValue.delete"
             ) {
                 objDel(valueToWrite, pathComponents)
                 continue

--- a/tests/driver/Firestore/InProcessFirestore.update.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.update.test.ts
@@ -1,3 +1,4 @@
+import { FieldValue } from "@google-cloud/firestore"
 import { GRPCStatusCode } from "../../../src/driver/Common/GRPCStatusCode"
 import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFirestore"
 
@@ -54,4 +55,34 @@ describe("InProcessFirestore update", () => {
             })
         },
     )
+
+    test(".doc().update() deleting existing field", async () => {
+        // Given there is a doc;
+        await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .create({
+                name: "thing",
+                good: true,
+                nop: null,
+            })
+
+        // When we set the doc with a different value;
+        await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .update({ name: FieldValue.delete() })
+
+        // Then the data should be stored correctly;
+        const stored = await firestore
+            .collection("myCollection")
+            .doc("id1")
+            .get()
+
+        expect(stored.exists).toBe(true)
+        expect(stored.data()).toEqual({
+            nop: null,
+            good: true,
+        })
+    })
 })


### PR DESCRIPTION
Firestore does not support deleting fields setting them to null. Instead, we need to populate it as `FieldValue.delete()`. 

Official docs https://firebase.google.com/docs/firestore/manage-data/delete-data