### PR TITLE
Handle nulls in document collection group queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freetrade-io/ts-firebase-driver-testing",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -114,12 +114,16 @@ export class InProcessFirestore implements IFirestore {
 
     collectionGroup(collectionId: string): IFirestoreQuery {
         const flattenStorage: any = (storage: any, key: string) => {
-            const children = Object.keys(storage)
-                .filter((childKey) => typeof storage[childKey] === "object")
-                .map((childKey) => flattenStorage(storage[childKey], key))
-            const mergedChildren = _.merge({}, storage, ...children)
-            return {
-                [key]: mergedChildren[key],
+            if (storage) {
+                const children = Object.keys(storage)
+                    .filter((childKey) => typeof storage[childKey] === "object")
+                    .map((childKey) => flattenStorage(storage[childKey], key))
+                const mergedChildren = _.merge({}, storage, ...children)
+                return {
+                    [key]: mergedChildren[key],
+                }
+            } else {
+                return null
             }
         }
         const newStorage = flattenStorage(this.storage, collectionId)

--- a/tests/driver/Firestore/InProcessFirestore.collectionGroup.get.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.collectionGroup.get.test.ts
@@ -83,4 +83,51 @@ describe("InProcessFirestore collectionGroup get", () => {
         expect(collectionSnapshot.docs).toHaveLength(0)
         expect(collectionSnapshot.docs).toEqual([])
     })
+
+    test(".collectionGroup() document contains nulls", async () => {
+        // Given there is a collection
+        firestore.resetStorage({
+            topLevelCollection: {
+                myCollection: {
+                    id1: { field: "value 1" },
+                    id2: { field: "value 2" },
+                    id3: { field: "value 3" },
+                },
+            },
+            anotherCollection: {
+                myCollection: {
+                    idA: { field: "value A" },
+                    idB: { field: null },
+                },
+            },
+        })
+
+        // When we get the collectionGroup
+        const collectionSnapshot = await firestore
+            .collectionGroup("myCollection")
+            .get()
+
+        // Then we should get the expected collection.
+        expect(collectionSnapshot.docs.map((doc) => doc.exists)).toEqual([
+            true,
+            true,
+            true,
+            true,
+            true,
+        ])
+        expect(collectionSnapshot.docs.map((doc) => doc.id)).toEqual([
+            "id1",
+            "id2",
+            "id3",
+            "idA",
+            "idB",
+        ])
+        expect(collectionSnapshot.docs.map((doc) => doc.data())).toEqual([
+            { field: "value 1" },
+            { field: "value 2" },
+            { field: "value 3" },
+            { field: "value A" },
+            { field: null },
+        ])
+    })
 })


### PR DESCRIPTION
Collection group queries where the document contained a null would error in the driver. These are now handled