### PR TITLE
Include the documents path in the already exists error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freetrade-io/ts-firebase-driver-testing",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Swap out Firebase as a driver for in-process testing",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -826,7 +826,7 @@ export class InProcessFirestoreDocRef implements IFirestoreDocRef {
         if (existing.exists) {
             throw new FirestoreError(
                 GRPCStatusCode.ALREADY_EXISTS,
-                `Document already exists: ${this.path}`,
+                `Document already exists: /documents/${this.path}`,
             )
         }
         InProcessFirestoreDocRef.validateNoUndefinedFields(data)
@@ -1194,7 +1194,7 @@ class InProcessFirestoreWriteBatch implements IFirestoreWriteBatch {
             if ((await documentRef.get()).exists) {
                 throw new FirestoreError(
                     GRPCStatusCode.ALREADY_EXISTS,
-                    `Document already exists: ${documentRef.path}`,
+                    `Document already exists: /documents/${documentRef.path}`,
                 )
             }
             return documentRef.set(data)
@@ -1300,7 +1300,7 @@ class InProcessFirestoreBulkWriter implements IFirestoreBulkWriter {
             if ((await documentRef.get()).exists) {
                 throw new FirestoreError(
                     GRPCStatusCode.ALREADY_EXISTS,
-                    `Document already exists: ${documentRef.path}`,
+                    `Document already exists: /documents/${documentRef.path}`,
                 )
             }
             await documentRef.set(data)

--- a/tests/driver/Firestore/InProcessFirestore.batch.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.batch.test.ts
@@ -150,7 +150,7 @@ describe("In-process Firestore batched writes", () => {
         // Then the write should fail;
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
-            new RegExp("animals/tiger"),
+            new RegExp("/documents/animals/tiger"),
         )
 
         // And the document should not be changed.

--- a/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.bulkWriter.test.ts
@@ -198,7 +198,7 @@ describe("In-process Firestore BulkWriter", () => {
         // Then the write should fail
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
-            new RegExp("animals/tiger"),
+            new RegExp("/documents/animals/tiger"),
         )
 
         // And the document should not be changed.

--- a/tests/driver/Firestore/InProcessFirestore.create.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.create.test.ts
@@ -45,7 +45,7 @@ describe("InProcessFirestore create", () => {
         // Then the write should fail;
         expect(error).isFirestoreErrorWithCode(
             GRPCStatusCode.ALREADY_EXISTS,
-            new RegExp("animals/tiger"),
+            new RegExp("/documents/animals/tiger"),
         )
 
         // And the document should not be changed.


### PR DESCRIPTION
The ALREADY_EXISTS error message thrown by the real firestore includes a `/documents/` path, and not just the collection path.

Invest sniffs the error message to determine if a already_exists occurs and is a `unique_doc`. I moved some tests from integration to story tests and discovered the driver didn't behave in the same way

![image](https://user-images.githubusercontent.com/102109/176181204-d7111b2c-6ab0-45d8-a22b-b77076fc26f3.png)
