### PR TITLE
Allow startAfter queries by document snapshots

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -423,7 +423,11 @@ export class InProcessFirestoreQuery implements IFirestoreQuery {
                 },
             )
 
-            return new InProcessFirestoreQuery(this.firestore, this.path, newQuery)
+            return new InProcessFirestoreQuery(
+                this.firestore,
+                this.path,
+                newQuery,
+            )
         }
 
         fieldValues.forEach((queryFieldValue: any, i: number) => {

--- a/tests/driver/Firestore/InProcessFirestore.collectionGroup.startAfter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.collectionGroup.startAfter.test.ts
@@ -130,4 +130,28 @@ describe("In-process Firestore start after query on collectionGroup", () => {
             result.docs.map((doc) => ({ id: doc.id, data: doc.data() })),
         ).toStrictEqual([{ id: "22da618d", data: { name: "aardvark" } }])
     })
+
+    test("startAfter document reference", async () => {
+        // Given there is a collection of documents with ids;
+        await db.doc("livingthings/animals/22da618d").set({ name: "aardvark" })
+        await db.doc("livingthings/animals/00a3382").set({ name: "badger" })
+        await db.doc("livingthings/animals/11cbe6b5").set({ name: "camel" })
+
+        const offsetReference = db.doc("livingthings/animals/00a3382")
+
+        // When we order the collection by the document id;
+        const result = await db
+            .collectionGroup("animals")
+            .orderBy("name")
+            .startAfter(offsetReference)
+            .get()
+
+        // Then we should get the collection ordered by that field.
+        expect(result.size).toBe(1)
+        expect(result.empty).toBeFalsy()
+        expect(result.docs).toHaveLength(1)
+        expect(result.docs.map((doc) => doc.data())).toStrictEqual([
+            { name: "camel" },
+        ])
+    })
 })

--- a/tests/driver/Firestore/InProcessFirestore.collectionGroup.startAfter.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.collectionGroup.startAfter.test.ts
@@ -139,7 +139,7 @@ describe("In-process Firestore start after query on collectionGroup", () => {
 
         const offsetReference = db.doc("livingthings/animals/00a3382")
 
-        // When we order the collection by the document id;
+        // When we order the collection by a value, and pass a document reference
         const result = await db
             .collectionGroup("animals")
             .orderBy("name")


### PR DESCRIPTION
Firestore allows `startAfter` pagination [using document snapshots](https://firebase.google.com/docs/firestore/query-data/query-cursors#web-version-8_4).

This allows the testing library to do the same.