### PR TITLE
fix: typing improvement

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,9 +20,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -1,4 +1,4 @@
-import { FieldValue } from "@google-cloud/firestore"
+import { Firestore } from "@google-cloud/firestore"
 import flatten from "flat"
 import _ from "lodash"
 import { Readable } from "stream"
@@ -59,6 +59,10 @@ export class InProcessFirestore implements IFirestore {
         public makeId: () => string = fireStoreLikeId,
         public storage = {},
     ) {}
+
+    asFirestore(): Firestore {
+        return this as unknown as Firestore
+    }
 
     collection(collectionPath: string): IFirestoreCollectionRef {
         return new InProcessFirestoreCollectionRef(

--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -61,7 +61,7 @@ export class InProcessFirestore implements IFirestore {
     ) {}
 
     asFirestore(): Firestore {
-        return this as unknown as Firestore
+        return (this as unknown) as Firestore
     }
 
     collection(collectionPath: string): IFirestoreCollectionRef {

--- a/tests/driver/Firestore/InProcessFirestore.batch.test.ts
+++ b/tests/driver/Firestore/InProcessFirestore.batch.test.ts
@@ -8,7 +8,7 @@ import { InProcessFirestore } from "../../../src/driver/Firestore/InProcessFires
 describe("In-process Firestore batched writes", () => {
     test("documentation example batch", async () => {
         // Given we have a in-process Firestore DB;
-        const db = new InProcessFirestore()
+        const db = new InProcessFirestore().asFirestore()
 
         // And there is some initial data;
         await db
@@ -110,7 +110,7 @@ describe("In-process Firestore batched writes", () => {
         "can set in batch on a document that doesn't exist, with merge %s",
         async (merge) => {
             // Given we have a in-process Firestore DB;
-            const db = new InProcessFirestore()
+            const db = new InProcessFirestore().asFirestore()
 
             // When we get a new write batch;
             const batch = db.batch()
@@ -127,7 +127,7 @@ describe("In-process Firestore batched writes", () => {
     )
 
     test("cannot create existing document in a batch write", async () => {
-        const db = new InProcessFirestore()
+        const db = new InProcessFirestore().asFirestore()
         // Given there is an existing document;
         const initial = await db
             .collection("animals")
@@ -164,7 +164,7 @@ describe("In-process Firestore batched writes", () => {
 
     test("cannot reuse committed batch", async () => {
         // Given we have a write batch;
-        const db = new InProcessFirestore()
+        const db = new InProcessFirestore().asFirestore()
         const batch = db.batch()
 
         // And we make a change in the batch;
@@ -192,10 +192,11 @@ describe("In-process Firestore batched writes", () => {
     test("throws if an undefined field is written in a batch", async () => {
         // Given we have a write batch;
         const db = new InProcessFirestore()
-        const batch = db.batch()
+        const fs = db.asFirestore()
+        const batch = fs.batch()
 
         // And we make a change in the batch;
-        const docRef = db.collection("things").doc("thingA")
+        const docRef = fs.collection("things").doc("thingA")
         batch.create(docRef, { foo: "bar", bar: undefined })
 
         // The commit should throw


### PR DESCRIPTION
Provide helper method for casting to `Firestore`.

Will simplify other code that does `db as unknown as Firestore`.