### PR TITLE
SAND-1027: Modified startAfter and Query for descending order

### DIFF
--- a/src/driver/Firestore/InProcessFirestore.ts
+++ b/src/driver/Firestore/InProcessFirestore.ts
@@ -251,7 +251,7 @@ interface IQueryBuilder {
     maps: Array<(item: IItem) => IItem>
     filters: Array<(idItem: IIdItem) => boolean>
     orderings: { [fieldPath: string]: (a: IIdItem, b: IIdItem) => number }
-    orderDirection: { [fieldPath: string]: "asc" | "desc"}
+    orderDirection: { [fieldPath: string]: "asc" | "desc" }
     transforms: Array<(collection: ICollection) => ICollection>
     rangeFilterField: string
 }


### PR DESCRIPTION
Adding support for order direction handling (asc or desc) in queries in InProcessFirestoreQuery class 
- added orderDirection valeue to track and apply ascending or descending order
- updated filtering in startAfter to correctly handle the specified order direction
- added new test cases to verify startAfter functionality